### PR TITLE
Move bthread prioritization into the bprograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,6 @@ The bprogram will select the next event based on the bids. Any event that is blo
 
 Bthreads are assigned a priority. The bprogram selects the bthread with a) the highest priority and b) at least one requested event that is not blocked.
 
-If all threads have the same priority, then the bid selection is random.
-
 ## Internal and External Events
 
 All events requested by bthreads will be handled before external events.

--- a/src/tech/thomascothran/pavlov/bprogram/ephemeral.cljc
+++ b/src/tech/thomascothran/pavlov/bprogram/ephemeral.cljc
@@ -108,6 +108,10 @@
 (defn make-program!
   "Create a behavioral program comprising bthreads.
 
+  `bthreads` is a collection of bthreads. Their priority
+  is determined by the order in which they are supplied.
+  ealier bthreads have higher priority.
+
   Returns the behavioral program."
   ([bthreads]
    (make-program! bthreads {}))

--- a/src/tech/thomascothran/pavlov/bthread/defaults.cljc
+++ b/src/tech/thomascothran/pavlov/bthread/defaults.cljc
@@ -3,25 +3,22 @@
 
 #?(:clj (extend-protocol bthread/BThread
           clojure.lang.APersistentMap
-          (name [this] (get this :name))
+          (name [this] this)
           (bid [this _event] this)
-          (priority [this] (get this :priority 0))
           (serialize [this] this)
           (deserialize [_this serialized] serialized))
 
    :cljs (extend-protocol bthread/BThread
 
            cljs.core.PersistentArrayMap
-           (name [this] (get this :name))
+           (name [this] this)
            (bid [this _event] this)
-           (priority [this] (get this :priority 0))
            (serialize [this] this)
            (deserialize [_this serialized] serialized)
 
            cljs.core.PersistentHashMap
-           (name [this] (get this name))
+           (name [this] this)
            (bid [this _event] this)
-           (priority [this] (get this :priority 0))
            (serialize [this] this)
            (deserialize [_this serialized] serialized)))
 
@@ -29,6 +26,5 @@
   nil
   (name [_] nil)
   (bid [this _event] this)
-  (priority [_] 0)
   (serialize [_] nil)
   (deserialize [_ _] nil))

--- a/src/tech/thomascothran/pavlov/bthread/proto.cljc
+++ b/src/tech/thomascothran/pavlov/bthread/proto.cljc
@@ -4,7 +4,5 @@
 (defprotocol BThread
   (name [this])
   (bid [this last-event])
-  (priority [this])
   (serialize [this])
   (deserialize [this serialized]))
-


### PR DESCRIPTION
Problem
-------
Bthreads are only prioritized in the context of a program. The same bthread may have a different priority in a different bprogram.

Further, for purposes of model checking, we can eliminate complexity by requiring that all bthreads have a distinct order with respect to each other.

Solution
--------
Bthread prioritization is done by passing an ordered sequence into the function that makes the bprogram.