### PR TITLE
Hot State Based Liveness Checking

### DIFF
--- a/modules/pavlov-devtools/build.clj
+++ b/modules/pavlov-devtools/build.clj
@@ -5,7 +5,7 @@
 
 (def lib 'tech.thomascothran/pavlov-devtools)
 ; alternatively, use MAJOR.MINOR.COMMITS:
-(def version (format "3.0.%s" (b/git-count-revs nil)))
+(def version (format "4.0.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 
 (defn- pom-template [version]

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/graph.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/graph.cljc
@@ -60,7 +60,8 @@
 
   Second, the eligible requested events from the eligible bid will be selected.
   These will then be aggregated together into the total branching events. "
-  (:require [tech.thomascothran.pavlov.search :as search]))
+  (:require [tech.thomascothran.pavlov.bid.proto :as bid]
+            [tech.thomascothran.pavlov.search :as search]))
 
 (defn- ->node-value
   "Extract minimal node data from wrapped state.
@@ -69,13 +70,17 @@
   fields like :path, :last-event, :next-event, and non-serializable
   fields like :name->bthread."
   [wrapped]
-  (let [bp-state (:bprogram/state wrapped)]
-    {:bthread->bid (:bthread->bid bp-state)
+  (let [bp-state (:bprogram/state wrapped)
+        bthread->bid (:bthread->bid bp-state)]
+    {:bthread->bid bthread->bid
      :bthreads-by-priority (:bthreads-by-priority bp-state)
      :saved-bthread-states (:saved-bthread-states wrapped)
      :requests (:requests bp-state)
      :waits (:waits bp-state)
-     :blocks (:blocks bp-state)}))
+     :blocks (:blocks bp-state)
+     :hot (boolean
+           (some bid/hot
+                 (vals bthread->bid)))}))
 
 (defn ->lts
   "Return a Labeled Transition System (LTS) for the supplied bthreads.
@@ -97,6 +102,7 @@
     :requests            - Map of event -> requesting bthreads
     :waits               - Map of event -> waiting bthreads
     :blocks              - Map of event -> blocking bthreads
+    :hot                 - True when any active bthread is hot
 
   Options:
     :max-nodes - Maximum nodes to explore before stopping (default: 1,000)

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/graph/algo.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/graph/algo.cljc
@@ -1,5 +1,5 @@
 (ns tech.thomascothran.pavlov.graph.algo
-  (:import [clojure.lang PersistentQueue]))
+  (:import #?(:clj [clojure.lang PersistentQueue])))
 
 (defn distinct-by
   "Returns a stateful transducer that removes elements by calling f on each step as a uniqueness key.
@@ -36,10 +36,14 @@
    :path (conj path edge)})
 
 (defn find-path
+  "Find a path from the starting node to a node whose id satisfies
+  `target-node-id-pred`."
   [start-id succ-fn target-node-id-pred]
   (loop [seen #{start-id}
-         frontier (conj PersistentQueue/EMPTY {:node-id start-id
-                                               :path []})]
+         frontier (conj #?(:clj PersistentQueue/EMPTY
+                           :cljs #queue [])
+                        {:node-id start-id
+                         :path []})]
     (when-let [frontier-state (peek frontier)]
       (let [node-id (get frontier-state :node-id)
             path (get frontier-state :path)]

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/graph/algo.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/graph/algo.cljc
@@ -1,0 +1,73 @@
+(ns tech.thomascothran.pavlov.graph.algo
+  (:import [clojure.lang PersistentQueue]))
+
+(defn distinct-by
+  "Returns a stateful transducer that removes elements by calling f on each step as a uniqueness key.
+   Returns a lazy sequence when provided with a collection.
+
+  Source: https://gist.github.com/thenonameguy/714b4a4aa5dacc204af60ca0cb15db43"
+  ([f]
+   (fn [rf]
+     (let [seen (volatile! #{})]
+       (fn
+         ([] (rf))
+         ([result] (rf result))
+         ([result input]
+          (let [v (f input)]
+            (if (contains? @seen v)
+              result
+              (do (vswap! seen conj v)
+                  (rf result input)))))))))
+  ([f xs]
+   (sequence (distinct-by f) xs)))
+
+(defn lts->outgoing-index
+  [lts]
+  (group-by :from (get lts :edges)))
+
+(defn succ
+  [outgoing-index edge-predicate node-id]
+  (some->> (get outgoing-index node-id)
+           (filter edge-predicate)))
+
+(defn- ->frontier-state
+  [path edge]
+  {:node-id (get edge :to)
+   :path (conj path edge)})
+
+(defn find-path
+  [start-id succ-fn target-node-id-pred]
+  (loop [seen #{start-id}
+         frontier (conj PersistentQueue/EMPTY {:node-id start-id
+                                               :path []})]
+    (when-let [frontier-state (peek frontier)]
+      (let [node-id (get frontier-state :node-id)
+            path (get frontier-state :path)]
+        (if (target-node-id-pred node-id)
+          path
+          (let [successors
+                (into []
+                      (comp (map (partial ->frontier-state path))
+                            (remove (comp seen :node-id))
+                            (distinct-by :node-id))
+                      (succ-fn node-id))]
+            (recur (into seen (map :node-id) successors)
+                   (into (pop frontier) successors))))))))
+
+(comment
+  *e
+  (do (require '[tech.thomascothran.pavlov.graph :as g])
+      (require '[tech.thomascothran.pavlov.bthread :as b])
+      (defn make-bthreads
+        []
+        {:a (b/bids [{:request #{:a}}])
+         :b (b/bids [{:wait-on #{:a}}
+                     {:request #{:b}}])
+         :c (b/bids [{:wait-on #{:b}}
+                     {:request #{:c}}])})
+      (def lts
+        (g/->lts (make-bthreads)))
+      (lts->outgoing-index lts)
+      (succ (lts->outgoing-index lts)
+            (constantly true)
+            (get lts :root))))

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
@@ -42,7 +42,7 @@
 
   ```clojure
   {:livelocks [{:path [...] :cycle [...]}]
-   :liveness-violations [{:node-id ... :path-edges [...] :state {...}}]
+   :liveness-violation {:node-id ... :path-edges [...] :state {...}}
    :impossible #{:event-a :event-b}
    :safety-violations [{:event {...} :path [...] :state {...}}]
    :deadlocks [{:path [...] :state {...}}]
@@ -50,7 +50,8 @@
   ```
 
   - `:livelocks` — Programs stuck in infinite loops
-  - `:liveness-violations` — Hot-state obligations that can remain unmet
+  - `:liveness-violation` — A hot state obligation that is not met. If there are
+    multiple unmet hot state obligations, only one is returned
   - `:impossible` — Requested possible events were not found in the fully explored LTS
   - `:safety-violations` — Invariants violated
   - `:deadlocks` — Programs stuck, no events possible
@@ -133,9 +134,9 @@
                 :await-payment (b/bids [{:wait-on #{:start-order}}
                                          {:wait-on #{:payment}
                                           :hot true}])}})
-  ;; => {:liveness-violations [{:node-id ...,
-  ;;                            :path-edges [...],
-  ;;                            :state {...}}]
+  ;; => {:liveness-violation {:node-id ...,
+  ;;                          :path-edges [...],
+  ;;                          :state {...}}]
   ;;     :deadlocks [{:path [:start-order], :state {...}}]}
   ```
 
@@ -174,11 +175,10 @@
 
   ## Multiple Violations
 
-  When multiple issues exist, ALL violations are returned in a single categorized map.
   Fix violations in this recommended order (most severe first):
 
   1. **Livelocks** — Most severe (pegs CPU at 100%)
-  2. **Liveness violations** — Hot-state obligations can remain unmet
+  2. **Liveness violation** — An unmet hot-state obligation
   3. **Safety violations** — Bad states reached
   4. **Deadlocks** — Programs stuck
 

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
@@ -32,7 +32,7 @@
   | `:environment-bthreads` | map/vec | nil | Bthreads simulating external inputs |
   | `:check-deadlock?` | bool | true | Whether to detect deadlocks |
   | `:check-livelock?` | bool | true | Whether to detect livelocks (infinite loops) |
-  | `:liveness` | map | nil | Liveness properties to verify (see below) |
+  | `:possible` | set | nil | Events that must be reachable on at least one path |
   | `:max-nodes` | int | nil | Limit state space exploration |
 
   ### Return Values
@@ -42,7 +42,7 @@
 
   ```clojure
   {:livelocks [{:path [...] :cycle [...]}]
-   :liveness-violations [{:property ... :quantifier ... :trace [...]}]
+   :liveness-violations [{:node-id ... :path-edges [...] :state {...}}]
    :impossible #{:event-a :event-b}
    :safety-violations [{:event {...} :path [...] :state {...}}]
    :deadlocks [{:path [...] :state {...}}]
@@ -50,8 +50,8 @@
   ```
 
   - `:livelocks` — Programs stuck in infinite loops
-  - `:liveness-violations` — Required events never occur
-  - `:impossible` — Requested possible events were not found in the explored LTS
+  - `:liveness-violations` — Hot-state obligations that can remain unmet
+  - `:impossible` — Requested possible events were not found in the fully explored LTS
   - `:safety-violations` — Invariants violated
   - `:deadlocks` — Programs stuck, no events possible
   - `:truncated` — Boolean flag when exploration hit `:max-nodes` limit
@@ -119,28 +119,24 @@
   ;; => {:safety-violations [{:event {:type :double-work-error, ...}, :path [...], :state {...}}]}
   ```
 
-  ### Liveness Properties
+  ### Hot-State Liveness
 
-  Liveness properties assert that \"something good eventually happens\"
-  by matching individual reachable events. Use the `:liveness` option to
-  specify properties.
-
-  #### Universal Quantifier (`:universal`)
-
-  The property must be satisfied on ALL execution paths.
+  Liveness is expressed behaviorally with `:hot true` on bids. A violation
+  exists when execution terminates while hot, deadlocks while hot, or can stay
+  in hot states forever.
 
   ```clojure
-  ;; Assert: payment MUST eventually occur on every path
+  ;; After :start-order, payment becomes a hot obligation.
+  ;; Because nothing can produce :payment here, the program deadlocks while hot.
   (check/check
-    {:bthreads {:flow (b/bids [{:request #{:process}}
-                               {:request #{{:type :done :terminal true}}}])}
-     :liveness
-     {:payment-required
-      {:quantifier :universal
-       :eventually #{:payment}}}})
-  ;; => {:liveness-violations [{:property :payment-required,
-  ;;                            :quantifier :universal,
-  ;;                            :trace [:process :done]}]}
+    {:bthreads {:order (b/bids [{:request #{:start-order}}])
+                :await-payment (b/bids [{:wait-on #{:start-order}}
+                                         {:wait-on #{:payment}
+                                          :hot true}])}})
+  ;; => {:liveness-violations [{:node-id ...,
+  ;;                            :path-edges [...],
+  ;;                            :state {...}}]
+  ;;     :deadlocks [{:path [:start-order], :state {...}}]}
   ```
 
   ### Possibility Checks
@@ -158,24 +154,6 @@
      :possible #{:payment}})
   ;; => nil (satisfied - path-a has payment)
   ```
-
-  #### Event Predicate Form
-
-  For more precise event-local matching, use `:event-predicate`:
-
-  ```clojure
-  (check/check
-    {:bthreads {...}
-     :liveness
-     {:order-complete
-       {:quantifier :universal
-        :event-predicate (fn [event]
-                           (contains? #{:payment :shipment}
-                                      (tech.thomascothran.pavlov.event/type event)))}}})
-  ```
-
-  Legacy trace-based `:predicate` is rejected because liveness is evaluated
-  on a state-merged LTS and must remain event-local.
 
   ## Environment Bthreads
 
@@ -200,7 +178,7 @@
   Fix violations in this recommended order (most severe first):
 
   1. **Livelocks** — Most severe (pegs CPU at 100%)
-  2. **Liveness violations** — Required properties never satisfied
+  2. **Liveness violations** — Hot-state obligations can remain unmet
   3. **Safety violations** — Bad states reached
   4. **Deadlocks** — Programs stuck
 
@@ -233,7 +211,7 @@
      in the execution graph and kicking things off
   3. Specify positive scenarios and validate they occur with possibility checks
   4. Specify safety properties as their own bthreads
-  5. Specify universal liveness properties
+  5. Specify hot-state obligations with `:hot true` where progress is required
 
   ### One branching request for all initiating events
 
@@ -246,11 +224,12 @@
   use `b/bid` with `:wait-on` events. `b/bid` can be used either with maps or functions.
 
   The final bid will `:request` an event unique to the scenario which will then be used
-  with liveness checks to guarantee the scenario reached completion.
+  with possibility checks to guarantee the scenario reached completion.
   "
   (:require [clojure.set :as set]
             [tech.thomascothran.pavlov.event :as e]
-            [tech.thomascothran.pavlov.graph :as graph])
+            [tech.thomascothran.pavlov.graph :as graph]
+            [tech.thomascothran.pavlov.model.check.liveness :as liveness])
   (:import [clojure.lang PersistentQueue]))
 
 ;; Internal implementation details below
@@ -449,46 +428,6 @@
               [{:path (or (find-path lts cycle-entry-node) [])
                 :cycle cycle-path}])))))))
 
-(defn- check-universal-liveness
-  "Check a universal event-local liveness property.
-   Returns violations for maximal reachable executions with no matching event."
-  [lts property-key {:keys [eventually event-predicate]} terminal-node-ids]
-  (let [event-ok? (or event-predicate
-                      (when eventually
-                        #(contains? eventually (e/type %))))
-        bad-edge-lts (when event-ok?
-                       (update lts :edges
-                               (fn [edges]
-                                 (filterv (fn [{:keys [event]}]
-                                            (not (event-ok? event)))
-                                          edges))))
-         ;; Collect all terminating path violations
-        terminating-violations
-        (vec (for [terminal-node-id terminal-node-ids
-                   :let [keyword-trace (if bad-edge-lts
-                                         (find-path bad-edge-lts terminal-node-id)
-                                         (find-path lts terminal-node-id))]
-                   :when (some? keyword-trace)]
-               {:property property-key
-                :quantifier :universal
-                :trace keyword-trace}))
-
-        ;; Check trapped cycles
-        cycle-violations
-        (when-let [can-reach (nodes-reaching-terminal lts)]
-          (let [all-nodes (set (keys (:nodes lts)))
-                trapped (set/difference all-nodes can-reach)]
-            (when (seq trapped)
-              (when-let [{:keys [cycle-path cycle-events]} (find-cycle-in-nodes lts trapped)]
-                (let [violation? (not (some event-ok? cycle-events))]
-                  (when violation?
-                    [{:property property-key
-                      :quantifier :universal
-                      :cycle cycle-path}]))))))]
-
-    ;; Combine all violations
-    (vec (concat terminating-violations cycle-violations))))
-
 (defn- find-impossible-events
   "Return the subset of `:possible` events that do not appear on any explored edge."
   [lts config]
@@ -507,39 +446,12 @@
                        {:request #{:c}}])})
       (find-impossible-events {:possible #{:d}})))
 
-(defn- find-liveness-violations
-  "Check liveness properties against the LTS graph.
-   Returns violations for maximal executions with no matching event.
-
-   Checks deadlock/terminal paths and trapped cycles using event-local semantics.
-
-   Supports :eventually shorthand and :event-predicate for event-local matching.
-
-   Returns a vector of all liveness violations (without :type key)."
-  [lts config]
-  (when-let [liveness-props (:liveness config)]
-    (let [terminal-node-ids (terminal-nodes lts)
-          ;; Also find deadlock nodes - these are leaf nodes that are not terminal
-          {:keys [edges nodes]} lts
-          nodes-with-outgoing (into #{} (map :from edges))
-          leaf-nodes (remove nodes-with-outgoing (keys nodes))
-          deadlock-node-ids (set (remove terminal-node-ids leaf-nodes))
-          ;; Combine terminal and deadlock nodes for liveness checking
-          nodes-to-check (into terminal-node-ids deadlock-node-ids)]
-       ;; Collect violations from all liveness properties
-      (vec (mapcat (fn [[property-key prop]]
-                     (let [{:keys [quantifier]} prop]
-                       (case quantifier
-                         :universal
-                         (check-universal-liveness lts property-key prop nodes-to-check))))
-                   liveness-props)))))
-
 (defn check
   "Model check a behavioral program for safety violations.
 
   Explores the state space once, checking for:
   - Livelocks (cycles with no path to terminal, unless :check-livelock? is false)
-  - Liveness violations (properties not satisfied on paths, when :liveness is provided)
+  - Liveness violations (hot terminal, hot deadlock, or hot cycle). Returns at most 1
   - Safety violations (events with :invariant-violated true)
   - Deadlocks (unless :check-deadlock? is false)
 
@@ -550,7 +462,6 @@
     :environment-bthreads - bthreads that generate events
     :check-livelock? - if true, detect livelocks (default: true)
     :check-deadlock? - if true, detect deadlocks (default: true)
-    :liveness - map of liveness properties to check (optional)
     :possible (optional) - a set of events that must be possible
     :max-nodes - maximum nodes to explore (optional)
 
@@ -558,7 +469,7 @@
   - nil if no violations found
   - A map with violation categories (only non-empty categories included):
     {:livelocks [{:path [...] :cycle [...]}]
-     :liveness-violations [{:property ... :quantifier ... :trace [...]}]
+     :liveness-violation {:node-id ... :path-edges [...] :state {...}} ;; at most 1
      :impossible #{:event-a :event-b} ;; impossible events
      :safety-violations [{:event ... :path [...] :state {...}}]
      :deadlocks [{:path [...] :state {...}}]
@@ -580,20 +491,22 @@
                                       {:lts lts
                                        :config config}))))
         ;; Don't report liveness violations if truncated (likely false positives)
-        liveness-violations (when-not truncated?
-                              (find-liveness-violations lts config))
+        liveness-violation  (when-not truncated?
+                              (liveness/liveness-violation lts))
         safety-violations (find-safety-violations lts)
         ;; Don't report deadlocks if truncated (likely false positives)
         deadlocks (when-not truncated?
                     (find-deadlocks lts config))
 
-        impossible (find-impossible-events lts config)
+        ;; Don't report impossible events if truncated (likely false negatives)
+        impossible (when-not truncated?
+                     (find-impossible-events lts config))
 
         ;; Build categorized result map - only include non-empty categories
         result (cond-> nil
                  (seq impossible) (assoc :impossible impossible)
                  (seq livelocks) (assoc :livelocks livelocks)
-                 (seq liveness-violations) (assoc :liveness-violations liveness-violations)
+                 (seq liveness-violation) (assoc :liveness-violation liveness-violation)
                  (seq safety-violations) (assoc :safety-violations safety-violations)
                  (seq deadlocks) (assoc :deadlocks deadlocks)
                  truncated? (assoc :truncated true))]

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
@@ -579,7 +579,9 @@
                       (throw (ex-info "livelock detection failed due to stack overflow. Possible circular node IDs."
                                       {:lts lts
                                        :config config}))))
-        liveness-violations (find-liveness-violations lts config)
+        ;; Don't report liveness violations if truncated (likely false positives)
+        liveness-violations (when-not truncated?
+                              (find-liveness-violations lts config))
         safety-violations (find-safety-violations lts)
         ;; Don't report deadlocks if truncated (likely false positives)
         deadlocks (when-not truncated?

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
@@ -119,8 +119,9 @@
 
   ### Liveness Properties
 
-  Liveness properties assert that \"something good eventually happens.\"
-  Use the `:liveness` option to specify properties.
+  Liveness properties assert that \"something good eventually happens\"
+  by matching individual reachable events. Use the `:liveness` option to
+  specify properties.
 
   #### Universal Quantifier (`:universal`)
 
@@ -158,22 +159,23 @@
   ;; => nil (satisfied - path-a has payment)
   ```
 
-  #### Predicate Form
+  #### Event Predicate Form
 
-  For complex conditions, use `:predicate` instead of `:eventually`:
+  For more precise event-local matching, use `:event-predicate`:
 
   ```clojure
   (check/check
     {:bthreads {...}
      :liveness
      {:order-complete
-      {:quantifier :universal
-       :predicate (fn [trace]
-                    ;; trace is a vector of event maps
-                    (let [types (map #(tech.thomascothran.pavlov.event/type %) trace)]
-                      (and (some #{:payment} types)
-                           (some #{:shipment} types))))}}})
+       {:quantifier :universal
+        :event-predicate (fn [event]
+                           (contains? #{:payment :shipment}
+                                      (tech.thomascothran.pavlov.event/type event)))}}})
   ```
+
+  Legacy trace-based `:predicate` is rejected because liveness is evaluated
+  on a state-merged LTS and must remain event-local.
 
   ## Environment Bthreads
 
@@ -366,7 +368,7 @@
 
 (defn- find-cycle-in-nodes
   "Find a cycle in the given set of nodes using DFS.
-  Returns {:cycle-path [events] :cycle-entry-node node-id} or nil."
+  Returns {:cycle-path [event-types] :cycle-events [events] :cycle-entry-node node-id} or nil."
   [lts trapped-nodes]
   (let [{:keys [edges root]} lts
         ;; Build adjacency map for trapped nodes only
@@ -378,7 +380,7 @@
                           edges)
 
         ;; DFS with path tracking and depth limit
-        ;; path-events: vector of events taken so far
+        ;; path-events: vector of full events taken so far
         ;; visited-in-path: map from node-id to index in path where we first visited it
         max-depth (* 2 (count trapped-nodes)) ;; Limit depth to prevent stack overflow
         dfs (fn dfs [node path-events visited-in-path visited-fully depth]
@@ -389,8 +391,10 @@
 
                 ;; Found a cycle!
                 (contains? visited-in-path node)
-                (let [cycle-start-idx (get visited-in-path node)]
-                  {:cycle-path (subvec path-events cycle-start-idx)
+                (let [cycle-start-idx (get visited-in-path node)
+                      cycle-events (subvec path-events cycle-start-idx)]
+                  {:cycle-path (mapv e/type cycle-events)
+                   :cycle-events cycle-events
                    :cycle-entry-node node})
 
                 ;; Already explored this node fully
@@ -402,12 +406,11 @@
                 (let [neighbors (get adjacency node [])
                       current-idx (count path-events)]
                   (some (fn [{:keys [to event]}]
-                          (let [event-val (e/type event)]
-                            (dfs to
-                                 (conj path-events event-val)
-                                 (assoc visited-in-path node current-idx)
-                                 (conj visited-fully node)
-                                 (inc depth))))
+                          (dfs to
+                               (conj path-events event)
+                               (assoc visited-in-path node current-idx)
+                               (conj visited-fully node)
+                               (inc depth)))
                         neighbors))))]
 
     ;; Start DFS from root if it's trapped, otherwise from any trapped node
@@ -446,43 +449,26 @@
               [{:path (or (find-path lts cycle-entry-node) [])
                 :cycle cycle-path}])))))))
 
-(defn- find-path-with-full-events
-  "Find a path from root to target node, returning full event maps.
-  Used by liveness checking where predicates need access to full event data.
-  Returns a vector of event maps, or nil if no path exists."
-  [lts target-id]
-  (let [{:keys [root edges]} lts
-        ;; Build adjacency map: node-id -> [{:to id :event e}]
-        adjacency (reduce (fn [acc {:keys [from to event]}]
-                            (update acc from (fnil conj []) {:to to :event event}))
-                          {}
-                          edges)]
-    (loop [queue (conj PersistentQueue/EMPTY {:id root :path []})
-           visited #{}]
-      (if-let [{:keys [id path]} (peek queue)]
-        (if (= id target-id)
-          path
-          (if (visited id)
-            (recur (pop queue) visited)
-            (let [neighbors (get adjacency id [])
-                  new-states (map (fn [{:keys [to event]}]
-                                    {:id to
-                                     :path (conj path event)}) ;; Full event map
-                                  neighbors)]
-              (recur (into (pop queue) new-states)
-                     (conj visited id)))))
-        nil))))
-
 (defn- check-universal-liveness
-  "Check a universal liveness property: all paths must satisfy the predicate.
-  Returns a vector of violations (one for each path that fails the predicate)."
-  [lts property-key {:keys [predicate eventually]} terminal-node-ids]
-  (let [;; Collect all terminating path violations
+  "Check a universal event-local liveness property.
+   Returns violations for maximal reachable executions with no matching event."
+  [lts property-key {:keys [eventually event-predicate]} terminal-node-ids]
+  (let [event-ok? (or event-predicate
+                      (when eventually
+                        #(contains? eventually (e/type %))))
+        bad-edge-lts (when event-ok?
+                       (update lts :edges
+                               (fn [edges]
+                                 (filterv (fn [{:keys [event]}]
+                                            (not (event-ok? event)))
+                                          edges))))
+         ;; Collect all terminating path violations
         terminating-violations
         (vec (for [terminal-node-id terminal-node-ids
-                   :let [full-event-trace (find-path-with-full-events lts terminal-node-id)
-                         keyword-trace (find-path lts terminal-node-id)]
-                   :when (not (predicate full-event-trace))]
+                   :let [keyword-trace (if bad-edge-lts
+                                         (find-path bad-edge-lts terminal-node-id)
+                                         (find-path lts terminal-node-id))]
+                   :when (some? keyword-trace)]
                {:property property-key
                 :quantifier :universal
                 :trace keyword-trace}))
@@ -493,17 +479,8 @@
           (let [all-nodes (set (keys (:nodes lts)))
                 trapped (set/difference all-nodes can-reach)]
             (when (seq trapped)
-              (when-let [{:keys [cycle-path]} (find-cycle-in-nodes lts trapped)]
-                ;; Check if cycle satisfies the liveness property
-                (let [violation? (cond
-                                   ;; For :eventually shorthand, check if any event in cycle matches
-                                   eventually
-                                   (not (some #(contains? eventually %) cycle-path))
-
-                                   ;; For :predicate, convert cycle to minimal event maps and run predicate
-                                   predicate
-                                   (let [cycle-as-trace (mapv (fn [kw] {:type kw}) cycle-path)]
-                                     (not (predicate cycle-as-trace))))]
+              (when-let [{:keys [cycle-path cycle-events]} (find-cycle-in-nodes lts trapped)]
+                (let [violation? (not (some event-ok? cycle-events))]
                   (when violation?
                     [{:property property-key
                       :quantifier :universal
@@ -513,51 +490,38 @@
     (vec (concat terminating-violations cycle-violations))))
 
 (defn- check-existential-liveness
-  "Check an existential liveness property: at least one path must satisfy the predicate.
-  Returns a vector with one violation if NO path satisfies the predicate, or empty vector if satisfied."
-  [lts property-key {:keys [predicate eventually]} terminal-node-ids]
-  (let [;; Check terminating paths
-        terminating-path-satisfies?
-        (some (fn [terminal-node-id]
-                (let [full-event-trace (find-path-with-full-events lts terminal-node-id)]
-                  (predicate full-event-trace)))
-              terminal-node-ids)
+  "Check an existential liveness property: at least one reachable event must satisfy the property.
+   Returns a vector with one violation if NO reachable event satisfies the property, or empty vector if satisfied."
+  [lts property-key {:keys [eventually event-predicate]} _terminal-node-ids]
+  (let [event-ok? (or event-predicate
+                      (when eventually
+                        #(contains? eventually (e/type %))))
+        satisfies? (some (fn [{:keys [event]}]
+                           (event-ok? event))
+                         (:edges lts))]
 
-        ;; Check if any cycle satisfies the predicate
-        cycle-satisfies?
-        (when-let [can-reach (nodes-reaching-terminal lts)]
-          (let [all-nodes (set (keys (:nodes lts)))
-                trapped (set/difference all-nodes can-reach)]
-            (when (seq trapped)
-              (when-let [{:keys [cycle-path]} (find-cycle-in-nodes lts trapped)]
-                (cond
-                  ;; For :eventually shorthand, check if any event in cycle matches
-                  eventually
-                  (some #(contains? eventually %) cycle-path)
-
-                  ;; For :predicate, convert cycle to minimal event maps and run predicate
-                  predicate
-                  (let [cycle-as-trace (mapv (fn [kw] {:type kw}) cycle-path)]
-                    (predicate cycle-as-trace)))))))]
-
-    ;; Return violation vector if neither terminating paths nor cycles satisfy
-    (if (or terminating-path-satisfies? cycle-satisfies?)
+    (if satisfies?
       []
       [{:property property-key
         :quantifier :existential}])))
 
+(defn- assert-supported-liveness-property!
+  [property-key {:keys [predicate]}]
+  (when predicate
+    (throw (ex-info (str "Legacy liveness :predicate is not supported for property " property-key
+                         ". Liveness checks must use supported event-local forms such as :eventually or :event-predicate.")
+                    {:property property-key}))))
+
 (defn- find-liveness-violations
   "Check liveness properties against the LTS graph.
-  For universal quantifier: returns violations for each path that fails the predicate.
-  For existential quantifier: returns violation if NO path satisfies the predicate.
+   For universal quantifier: returns violations for maximal executions with no matching event.
+   For existential quantifier: returns a violation if no reachable event satisfies the property.
 
-  Checks both terminating paths and trapped cycles.
+   Checks deadlock/terminal paths and trapped cycles using event-local semantics.
 
-  Supports :eventually shorthand: instead of providing a :predicate function,
-  you can provide :eventually with a set of event types. This creates a predicate
-  that checks if any event in the trace has a type in the :eventually set.
+   Supports :eventually shorthand and :event-predicate for event-local matching.
 
-  Returns a vector of all liveness violations (without :type key)."
+   Returns a vector of all liveness violations (without :type key)."
   [lts config]
   (when-let [liveness-props (:liveness config)]
     (let [terminal-node-ids (terminal-nodes lts)
@@ -568,22 +532,16 @@
           deadlock-node-ids (set (remove terminal-node-ids leaf-nodes))
           ;; Combine terminal and deadlock nodes for liveness checking
           nodes-to-check (into terminal-node-ids deadlock-node-ids)]
-      ;; Collect violations from all liveness properties
+       ;; Collect violations from all liveness properties
       (vec (mapcat (fn [[property-key prop]]
-                     (let [{:keys [quantifier predicate eventually]} prop
-                           ;; Transform :eventually to :predicate
-                           predicate (or predicate
-                                         (when eventually
-                                           (fn [trace]
-                                             (some #(contains? eventually (e/type %)) trace))))
-                           ;; Create prop with predicate for helpers
-                           prop-with-predicate (assoc prop :predicate predicate)]
+                     (let [_ (assert-supported-liveness-property! property-key prop)
+                           {:keys [quantifier]} prop]
                        (case quantifier
                          :universal
-                         (check-universal-liveness lts property-key prop-with-predicate nodes-to-check)
+                         (check-universal-liveness lts property-key prop nodes-to-check)
 
                          :existential
-                         (check-existential-liveness lts property-key prop-with-predicate nodes-to-check))))
+                         (check-existential-liveness lts property-key prop nodes-to-check))))
                    liveness-props)))))
 
 (defn check

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
@@ -43,6 +43,7 @@
   ```clojure
   {:livelocks [{:path [...] :cycle [...]}]
    :liveness-violations [{:property ... :quantifier ... :trace [...]}]
+   :impossible #{:event-a :event-b}
    :safety-violations [{:event {...} :path [...] :state {...}}]
    :deadlocks [{:path [...] :state {...}}]
    :truncated true}  ;; optional flag when max-nodes exceeded
@@ -50,6 +51,7 @@
 
   - `:livelocks` — Programs stuck in infinite loops
   - `:liveness-violations` — Required events never occur
+  - `:impossible` — Requested possible events were not found in the explored LTS
   - `:safety-violations` — Invariants violated
   - `:deadlocks` — Programs stuck, no events possible
   - `:truncated` — Boolean flag when exploration hit `:max-nodes` limit
@@ -141,9 +143,10 @@
   ;;                            :trace [:process :done]}]}
   ```
 
-  #### Existential Quantifier (`:existential`)
+  ### Possibility Checks
 
-  The property must be satisfied on AT LEAST ONE path.
+  Use `:possible` to assert that some event can occur on at least one reachable
+  execution.
 
   ```clojure
   ;; Assert: payment must be POSSIBLE (at least one path has it)
@@ -152,10 +155,7 @@
                                  {:request #{{:type :done-a :terminal true}}}])
                 :path-b (b/bids [{:request #{:skip}}
                                  {:request #{{:type :done-b :terminal true}}}])}
-     :liveness
-     {:payment-possible
-      {:quantifier :existential
-       :eventually #{:payment}}}})
+     :possible #{:payment}})
   ;; => nil (satisfied - path-a has payment)
   ```
 
@@ -231,7 +231,7 @@
   1. Decide what bthreads you want to test
   2. Specify initiating events in a single request, establishing top-level branches
      in the execution graph and kicking things off
-  3. Specify positive scenarios and validate they occur with existential liveness checks
+  3. Specify positive scenarios and validate they occur with possibility checks
   4. Specify safety properties as their own bthreads
   5. Specify universal liveness properties
 
@@ -489,33 +489,27 @@
     ;; Combine all violations
     (vec (concat terminating-violations cycle-violations))))
 
-(defn- check-existential-liveness
-  "Check an existential liveness property: at least one reachable event must satisfy the property.
-   Returns a vector with one violation if NO reachable event satisfies the property, or empty vector if satisfied."
-  [lts property-key {:keys [eventually event-predicate]} _terminal-node-ids]
-  (let [event-ok? (or event-predicate
-                      (when eventually
-                        #(contains? eventually (e/type %))))
-        satisfies? (some (fn [{:keys [event]}]
-                           (event-ok? event))
-                         (:edges lts))]
+(defn- find-impossible-events
+  "Return the subset of `:possible` events that do not appear on any explored edge."
+  [lts config]
+  (when-let [possible (get config :possible)]
+    (let [events (into #{}
+                       (comp (map :event)
+                             (map e/type))
+                       (get lts :edges))]
+      (set/difference possible events))))
 
-    (if satisfies?
-      []
-      [{:property property-key
-        :quantifier :existential}])))
-
-(defn- assert-supported-liveness-property!
-  [property-key {:keys [predicate]}]
-  (when predicate
-    (throw (ex-info (str "Legacy liveness :predicate is not supported for property " property-key
-                         ". Liveness checks must use supported event-local forms such as :eventually or :event-predicate.")
-                    {:property property-key}))))
+(comment
+  (require '[tech.thomascothran.pavlov.bthread :as b])
+  (-> (graph/->lts
+       {:a->c (b/bids [{:request #{:a}}
+                       {:request #{:b}}
+                       {:request #{:c}}])})
+      (find-impossible-events {:possible #{:d}})))
 
 (defn- find-liveness-violations
   "Check liveness properties against the LTS graph.
-   For universal quantifier: returns violations for maximal executions with no matching event.
-   For existential quantifier: returns a violation if no reachable event satisfies the property.
+   Returns violations for maximal executions with no matching event.
 
    Checks deadlock/terminal paths and trapped cycles using event-local semantics.
 
@@ -534,14 +528,10 @@
           nodes-to-check (into terminal-node-ids deadlock-node-ids)]
        ;; Collect violations from all liveness properties
       (vec (mapcat (fn [[property-key prop]]
-                     (let [_ (assert-supported-liveness-property! property-key prop)
-                           {:keys [quantifier]} prop]
+                     (let [{:keys [quantifier]} prop]
                        (case quantifier
                          :universal
-                         (check-universal-liveness lts property-key prop nodes-to-check)
-
-                         :existential
-                         (check-existential-liveness lts property-key prop nodes-to-check))))
+                         (check-universal-liveness lts property-key prop nodes-to-check))))
                    liveness-props)))))
 
 (defn check
@@ -561,6 +551,7 @@
     :check-livelock? - if true, detect livelocks (default: true)
     :check-deadlock? - if true, detect deadlocks (default: true)
     :liveness - map of liveness properties to check (optional)
+    :possible (optional) - a set of events that must be possible
     :max-nodes - maximum nodes to explore (optional)
 
   Returns:
@@ -568,6 +559,7 @@
   - A map with violation categories (only non-empty categories included):
     {:livelocks [{:path [...] :cycle [...]}]
      :liveness-violations [{:property ... :quantifier ... :trace [...]}]
+     :impossible #{:event-a :event-b} ;; impossible events
      :safety-violations [{:event ... :path [...] :state {...}}]
      :deadlocks [{:path [...] :state {...}}]
      :truncated true}  ;; optional flag when max-nodes exceeded"
@@ -593,8 +585,11 @@
         deadlocks (when-not truncated?
                     (find-deadlocks lts config))
 
+        impossible (find-impossible-events lts config)
+
         ;; Build categorized result map - only include non-empty categories
         result (cond-> nil
+                 (seq impossible) (assoc :impossible impossible)
                  (seq livelocks) (assoc :livelocks livelocks)
                  (seq liveness-violations) (assoc :liveness-violations liveness-violations)
                  (seq safety-violations) (assoc :safety-violations safety-violations)

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check.clj
@@ -38,7 +38,7 @@
   ### Return Values
 
   Returns `nil` if no violations found. Otherwise returns a categorized map
-  with violation vectors (only non-empty categories are included):
+  with only non-empty categories:
 
   ```clojure
   {:livelocks [{:path [...] :cycle [...]}]
@@ -136,7 +136,7 @@
                                           :hot true}])}})
   ;; => {:liveness-violation {:node-id ...,
   ;;                          :path-edges [...],
-  ;;                          :state {...}}]
+  ;;                          :state {...}}
   ;;     :deadlocks [{:path [:start-order], :state {...}}]}
   ```
 
@@ -451,7 +451,7 @@
 
   Explores the state space once, checking for:
   - Livelocks (cycles with no path to terminal, unless :check-livelock? is false)
-  - Liveness violations (hot terminal, hot deadlock, or hot cycle). Returns at most 1
+  - Liveness violation (hot terminal, hot deadlock, or hot cycle). Returns at most 1
   - Safety violations (events with :invariant-violated true)
   - Deadlocks (unless :check-deadlock? is false)
 
@@ -467,7 +467,7 @@
 
   Returns:
   - nil if no violations found
-  - A map with violation categories (only non-empty categories included):
+  - A map with non-empty result categories:
     {:livelocks [{:path [...] :cycle [...]}]
      :liveness-violation {:node-id ... :path-edges [...] :state {...}} ;; at most 1
      :impossible #{:event-a :event-b} ;; impossible events

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
@@ -50,24 +50,35 @@
      (some->> (algo/find-path (:root lts) succ-fn #(= % node-id))
               edge-path->event-types))))
 
-(defn- ordered-node-ids
-  [lts outgoing-index node-ids]
-  (let [path-cache (into {}
-                         (map (fn [node-id]
-                                [node-id
-                                  (or (path-to-node lts outgoing-index node-id) [])]))
-                         node-ids)]
-    (sort-by (juxt #(count (get path-cache %))
-                   #(pr-str (get path-cache %))
-                   str)
-             node-ids)))
+(defn- natural-node-order
+  [lts]
+  (let [{:keys [seen order]}
+        (reduce (fn [{:keys [seen order]} {:keys [from to]}]
+                  (let [[seen order]
+                        (if (contains? seen from)
+                          [seen order]
+                          [(conj seen from) (conj order from)])
+                        [seen order]
+                        (if (contains? seen to)
+                          [seen order]
+                          [(conj seen to) (conj order to)])]
+                    {:seen seen
+                     :order order}))
+                {:seen (cond-> #{}
+                         (:root lts) (conj (:root lts)))
+                 :order (cond-> []
+                          (:root lts) (conj (:root lts)))}
+                (:edges lts))]
+    (into order
+          (remove seen)
+          (keys (:nodes lts)))))
 
 (defn- hot-terminal-violation
   [lts outgoing-index]
   (when-let [edge (some (fn [edge]
                           (when (and (e/terminal? (:event edge))
                                      (hot? (get-in lts [:nodes (:to edge)])))
-                             edge))
+                            edge))
                         (:edges lts))]
     {:node-id (:to edge)
      :path (or (path-to-node lts outgoing-index (:to edge)) [])
@@ -75,15 +86,15 @@
 
 (defn- hot-deadlock-violation
   [lts outgoing-index]
-  (when-let [node-id (some (fn [node-id]
-                             (when (hot? (get-in lts [:nodes node-id]))
-                               node-id))
-                           (ordered-node-ids lts
-                                             outgoing-index
-                                             (deadlock-node-ids lts)))]
-    {:node-id node-id
-     :path (or (path-to-node lts outgoing-index node-id) [])
-     :state (get-in lts [:nodes node-id])}))
+  (let [deadlock-node-ids (deadlock-node-ids lts)]
+    (when-let [node-id (some (fn [node-id]
+                               (when (and (contains? deadlock-node-ids node-id)
+                                          (hot? (get-in lts [:nodes node-id])))
+                                 node-id))
+                             (natural-node-order lts))]
+      {:node-id node-id
+       :path (or (path-to-node lts outgoing-index node-id) [])
+       :state (get-in lts [:nodes node-id])})))
 
 (defn- hot-cycle
   [lts outgoing-index]
@@ -94,8 +105,10 @@
                    (algo/succ outgoing-index
                               (comp hot-node-id? :to)
                               node-id))
-        ordered-hot-node-ids (ordered-node-ids lts outgoing-index hot-node-ids)]
-    (loop [state {:start-node-ids ordered-hot-node-ids
+        start-node-ids (into []
+                             (filter hot-node-id?)
+                             (natural-node-order lts))]
+    (loop [state {:start-node-ids start-node-ids
                   :gray #{}
                   :black #{}
                   :stack []

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
@@ -1,0 +1,174 @@
+(ns tech.thomascothran.pavlov.model.check.liveness
+  (:require [clojure.set :as set]
+            [tech.thomascothran.pavlov.bid.proto :as bid]
+            [tech.thomascothran.pavlov.event :as e]
+            [tech.thomascothran.pavlov.graph.algo :as algo]))
+
+(defn hot?
+  [node]
+  (boolean
+   (some bid/hot
+         (vals (:bthread->bid node)))))
+
+(defn hot-node-ids
+  [lts]
+  (into #{}
+        (comp (filter (comp hot? second))
+              (map first))
+        (:nodes lts)))
+
+(defn leaf-node-ids
+  [lts]
+  (let [all-node-ids (into #{} (keys (:nodes lts)))
+        nodes-with-outgoing (into #{} (map :from) (:edges lts))]
+    (set/difference all-node-ids nodes-with-outgoing)))
+
+(defn terminal-target-node-ids
+  [lts]
+  (into #{}
+        (comp (filter (comp e/terminal? :event))
+              (map :to))
+        (:edges lts)))
+
+(defn deadlock-node-ids
+  [lts]
+  (set/difference (leaf-node-ids lts)
+                  (terminal-target-node-ids lts)))
+
+(defn edge-path->event-types
+  [edge-path]
+  (mapv (comp e/type :event) edge-path))
+
+(defn path-to-node
+  ([lts node-id]
+   (path-to-node lts (algo/lts->outgoing-index lts) node-id))
+  ([lts outgoing-index node-id]
+   (let [succ-fn (fn [curr-node-id]
+                   (algo/succ outgoing-index
+                              (constantly true)
+                              curr-node-id))]
+     (some->> (algo/find-path (:root lts) succ-fn #(= % node-id))
+              edge-path->event-types))))
+
+(defn- ordered-node-ids
+  [lts outgoing-index node-ids]
+  (let [path-cache (into {}
+                         (map (fn [node-id]
+                                [node-id
+                                  (or (path-to-node lts outgoing-index node-id) [])]))
+                         node-ids)]
+    (sort-by (juxt #(count (get path-cache %))
+                   #(pr-str (get path-cache %))
+                   str)
+             node-ids)))
+
+(defn- hot-terminal-violation
+  [lts outgoing-index]
+  (when-let [edge (some (fn [edge]
+                          (when (and (e/terminal? (:event edge))
+                                     (hot? (get-in lts [:nodes (:to edge)])))
+                             edge))
+                        (:edges lts))]
+    {:node-id (:to edge)
+     :path (or (path-to-node lts outgoing-index (:to edge)) [])
+     :state (get-in lts [:nodes (:to edge)])}))
+
+(defn- hot-deadlock-violation
+  [lts outgoing-index]
+  (when-let [node-id (some (fn [node-id]
+                             (when (hot? (get-in lts [:nodes node-id]))
+                               node-id))
+                           (ordered-node-ids lts
+                                             outgoing-index
+                                             (deadlock-node-ids lts)))]
+    {:node-id node-id
+     :path (or (path-to-node lts outgoing-index node-id) [])
+     :state (get-in lts [:nodes node-id])}))
+
+(defn- hot-cycle
+  [lts outgoing-index]
+  (let [hot-node-ids (hot-node-ids lts)
+        hot-node-id? (fn [node-id]
+                       (contains? hot-node-ids node-id))
+        hot-succ (fn [node-id]
+                   (algo/succ outgoing-index
+                              (comp hot-node-id? :to)
+                              node-id))
+        ordered-hot-node-ids (ordered-node-ids lts outgoing-index hot-node-ids)]
+    (loop [state {:start-node-ids ordered-hot-node-ids
+                  :gray #{}
+                  :black #{}
+                  :stack []
+                  :edge-stack []
+                  :node-id->edge-index {}}]
+      (let [{:keys [start-node-ids gray black stack edge-stack node-id->edge-index]}
+            state
+            next-step
+            (cond
+              (seq stack)
+              (let [{:keys [node-id remaining-edges]} (peek stack)]
+                (if-let [edge (first remaining-edges)]
+                  (let [successor-id (:to edge)
+                        stack' (conj (pop stack)
+                                     {:node-id node-id
+                                      :remaining-edges (next remaining-edges)})
+                        edge-stack' (conj edge-stack edge)]
+                    (cond
+                      (contains? gray successor-id)
+                      {:result {:entry-node-id successor-id
+                                :cycle-edges (subvec edge-stack'
+                                                     (get node-id->edge-index successor-id))}}
+
+                      (contains? black successor-id)
+                      {:state (assoc state :stack stack')}
+
+                      :else
+                      {:state (assoc state
+                                     :gray (conj gray successor-id)
+                                     :stack (conj stack'
+                                                  {:node-id successor-id
+                                                   :remaining-edges (seq (hot-succ successor-id))})
+                                     :edge-stack edge-stack'
+                                     :node-id->edge-index (assoc node-id->edge-index
+                                                                 successor-id
+                                                                 (count edge-stack')))}))
+                  {:state (assoc state
+                                 :gray (disj gray node-id)
+                                 :black (conj black node-id)
+                                 :stack (pop stack)
+                                 :edge-stack (if (> (count stack) 1)
+                                               (pop edge-stack)
+                                               edge-stack)
+                                 :node-id->edge-index (dissoc node-id->edge-index node-id))}))
+
+              (seq start-node-ids)
+              (let [start-node-id (first start-node-ids)
+                    remaining-start-node-ids (rest start-node-ids)]
+                (if (or (contains? gray start-node-id)
+                        (contains? black start-node-id))
+                  {:state (assoc state :start-node-ids remaining-start-node-ids)}
+                  {:state (assoc state
+                                 :start-node-ids remaining-start-node-ids
+                                 :gray (conj gray start-node-id)
+                                 :stack [{:node-id start-node-id
+                                          :remaining-edges (seq (hot-succ start-node-id))}]
+                                 :edge-stack []
+                                 :node-id->edge-index {start-node-id 0})}))
+
+              :else
+              {:result nil})]
+        (if (contains? next-step :result)
+          (:result next-step)
+          (recur (:state next-step)))))))
+
+(defn liveness-violation
+  ([lts]
+   (liveness-violation lts (algo/lts->outgoing-index lts)))
+  ([lts outgoing-index]
+   (or (hot-terminal-violation lts outgoing-index)
+       (hot-deadlock-violation lts outgoing-index)
+       (when-let [{:keys [entry-node-id cycle-edges]} (hot-cycle lts outgoing-index)]
+         {:node-id entry-node-id
+          :path (or (path-to-node lts outgoing-index entry-node-id) [])
+          :cycle (edge-path->event-types cycle-edges)
+          :state (get-in lts [:nodes entry-node-id])}))))

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
@@ -180,6 +180,22 @@
           (recur (:state next-step)))))))
 
 (defn liveness-violation
+  "Return the first hot-state liveness violation in the LTS, or nil.
+
+   A violation exists when:
+   - a terminal edge reaches a hot node
+   - a reachable non-terminal deadlock node is hot
+   - a reachable cycle through only hot nodes exists
+
+   Returns a map with:
+   - `:node-id` - the violating node or cycle-entry node
+   - `:path-edges` - a vector of edges from `:root` to `:node-id`
+   - `:cycle-edges` - a vector of cycle edges when the violation is cyclic
+   - `:state` - the node payload for `:node-id`
+
+   Does not return the legacy `:path` / `:cycle` keys.
+
+   Returns nil when no violation is found or when the LTS is truncated."
   ([lts]
    (liveness-violation lts (algo/lts->outgoing-index lts)))
   ([lts outgoing-index]

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
@@ -35,10 +35,6 @@
   (set/difference (leaf-node-ids lts)
                   (terminal-target-node-ids lts)))
 
-(defn edge-path->event-types
-  [edge-path]
-  (mapv (comp e/type :event) edge-path))
-
 (defn path-to-node
   ([lts node-id]
    (path-to-node lts (algo/lts->outgoing-index lts) node-id))
@@ -47,8 +43,13 @@
                    (algo/succ outgoing-index
                               (constantly true)
                               curr-node-id))]
-     (some->> (algo/find-path (:root lts) succ-fn #(= % node-id))
-              edge-path->event-types))))
+     (algo/find-path (:root lts) succ-fn #(= % node-id)))))
+
+(defn- witness-path-to-node
+  [lts outgoing-index node-id]
+  (if (= (:root lts) node-id)
+    []
+    (path-to-node lts outgoing-index node-id)))
 
 (defn- natural-node-order
   [lts]
@@ -80,20 +81,24 @@
                                      (hot? (get-in lts [:nodes (:to edge)])))
                             edge))
                         (:edges lts))]
-    {:node-id (:to edge)
-     :path (or (path-to-node lts outgoing-index (:to edge)) [])
-     :state (get-in lts [:nodes (:to edge)])}))
+    (when-let [prefix-path (witness-path-to-node lts outgoing-index (:from edge))]
+      {:node-id (:to edge)
+       :path-edges (conj prefix-path edge)
+       :state (get-in lts [:nodes (:to edge)])})))
 
 (defn- hot-deadlock-violation
   [lts outgoing-index]
   (let [deadlock-node-ids (deadlock-node-ids lts)]
-    (when-let [node-id (some (fn [node-id]
-                               (when (and (contains? deadlock-node-ids node-id)
-                                          (hot? (get-in lts [:nodes node-id])))
-                                 node-id))
-                             (natural-node-order lts))]
+    (when-let [{:keys [node-id path-edges]}
+               (some (fn [node-id]
+                       (when (and (contains? deadlock-node-ids node-id)
+                                  (hot? (get-in lts [:nodes node-id])))
+                         (when-let [path-edges (witness-path-to-node lts outgoing-index node-id)]
+                           {:node-id node-id
+                            :path-edges path-edges})))
+                     (natural-node-order lts))]
       {:node-id node-id
-       :path (or (path-to-node lts outgoing-index node-id) [])
+       :path-edges path-edges
        :state (get-in lts [:nodes node-id])})))
 
 (defn- hot-cycle
@@ -178,10 +183,11 @@
   ([lts]
    (liveness-violation lts (algo/lts->outgoing-index lts)))
   ([lts outgoing-index]
-   (or (hot-terminal-violation lts outgoing-index)
-       (hot-deadlock-violation lts outgoing-index)
-       (when-let [{:keys [entry-node-id cycle-edges]} (hot-cycle lts outgoing-index)]
-         {:node-id entry-node-id
-          :path (or (path-to-node lts outgoing-index entry-node-id) [])
-          :cycle (edge-path->event-types cycle-edges)
-          :state (get-in lts [:nodes entry-node-id])}))))
+   (when-not (:truncated lts)
+     (or (hot-terminal-violation lts outgoing-index)
+         (hot-deadlock-violation lts outgoing-index)
+         (when-let [{:keys [entry-node-id cycle-edges]} (hot-cycle lts outgoing-index)]
+           {:node-id entry-node-id
+            :path-edges (witness-path-to-node lts outgoing-index entry-node-id)
+            :cycle-edges cycle-edges
+            :state (get-in lts [:nodes entry-node-id])})))))

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/model/check/liveness.cljc
@@ -1,19 +1,12 @@
 (ns tech.thomascothran.pavlov.model.check.liveness
   (:require [clojure.set :as set]
-            [tech.thomascothran.pavlov.bid.proto :as bid]
             [tech.thomascothran.pavlov.event :as e]
             [tech.thomascothran.pavlov.graph.algo :as algo]))
-
-(defn hot?
-  [node]
-  (boolean
-   (some bid/hot
-         (vals (:bthread->bid node)))))
 
 (defn hot-node-ids
   [lts]
   (into #{}
-        (comp (filter (comp hot? second))
+        (comp (filter (comp :hot second))
               (map first))
         (:nodes lts)))
 
@@ -78,8 +71,8 @@
   [lts outgoing-index]
   (when-let [edge (some (fn [edge]
                           (when (and (e/terminal? (:event edge))
-                                     (hot? (get-in lts [:nodes (:to edge)])))
-                            edge))
+                                     (:hot (get-in lts [:nodes (:to edge)])))
+                             edge))
                         (:edges lts))]
     (when-let [prefix-path (witness-path-to-node lts outgoing-index (:from edge))]
       {:node-id (:to edge)
@@ -92,10 +85,10 @@
     (when-let [{:keys [node-id path-edges]}
                (some (fn [node-id]
                        (when (and (contains? deadlock-node-ids node-id)
-                                  (hot? (get-in lts [:nodes node-id])))
-                         (when-let [path-edges (witness-path-to-node lts outgoing-index node-id)]
-                           {:node-id node-id
-                            :path-edges path-edges})))
+                                  (:hot (get-in lts [:nodes node-id])))
+                          (when-let [path-edges (witness-path-to-node lts outgoing-index node-id)]
+                            {:node-id node-id
+                             :path-edges path-edges})))
                      (natural-node-order lts))]
       {:node-id node-id
        :path-edges path-edges

--- a/modules/pavlov-devtools/src/tech/thomascothran/pavlov/search.cljc
+++ b/modules/pavlov-devtools/src/tech/thomascothran/pavlov/search.cljc
@@ -1,6 +1,7 @@
 (ns tech.thomascothran.pavlov.search
   (:refer-clojure :exclude [ancestors])
   (:require [tech.thomascothran.pavlov.event.selection :as selection]
+            [tech.thomascothran.pavlov.event :as event]
             [tech.thomascothran.pavlov.bthread :as b]
             [tech.thomascothran.pavlov.bprogram.state :as state]
             [tech.thomascothran.pavlov.bid.proto :as bid]

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/graph/algo_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/graph/algo_test.clj
@@ -1,0 +1,31 @@
+(ns tech.thomascothran.pavlov.graph.algo-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [tech.thomascothran.pavlov.graph.algo
+             :as algo]
+            [tech.thomascothran.pavlov.bthread :as b]
+            [tech.thomascothran.pavlov.graph :as g]))
+
+(deftest test-find-path-linear
+  (let [bthreads
+        {:a (b/bids [{:request #{:a}}])
+         :b (b/bids [{:wait-on #{:a}}
+                     {:request #{:b}}])
+         :c (b/bids [{:wait-on #{:b}}
+                     {:request #{:c}}])}
+        lts (g/->lts bthreads)
+
+        root-node-id (get lts :root)
+
+        terminal-node-ids (->> (get lts :nodes)
+                               (filter (comp empty? :requests second))
+                               ffirst
+                               (conj #{}))
+
+        outgoing-index (algo/lts->outgoing-index lts)
+
+        path
+        (algo/find-path root-node-id
+                        (partial algo/succ outgoing-index (constantly true))
+                        terminal-node-ids)]
+
+    (is (= [:a :b :c] (mapv :event path)))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/graph_test.cljc
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/graph_test.cljc
@@ -170,12 +170,15 @@
       (is (contains? node-value :waits)
           "Node should contain :waits key (derived map)")
 
-      (is (contains? node-value :blocks)
-          "Node should contain :blocks key (derived map)")
+       (is (contains? node-value :blocks)
+           "Node should contain :blocks key (derived map)")
 
-      ;; Verify unwanted keys are NOT present (flattened structure)
-      (is (not (contains? node-value :path))
-          "Node should NOT contain :path key (multiple paths can lead to same node)")
+       (is (contains? node-value :hot)
+           "Node should contain :hot key")
+
+       ;; Verify unwanted keys are NOT present (flattened structure)
+       (is (not (contains? node-value :path))
+           "Node should NOT contain :path key (multiple paths can lead to same node)")
 
       (is (not (contains? node-value :last-event))
           "Node should NOT contain :last-event key")

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/graph_test.cljc
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/graph_test.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest is testing]]
             [clojure.set]
             [tech.thomascothran.pavlov.graph :as graph]
+            [tech.thomascothran.pavlov.model.check.liveness :as liveness]
             [tech.thomascothran.pavlov.nav :as pnav]
             [tech.thomascothran.pavlov.bthread :as b]))
 

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_cycle_witness_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_cycle_witness_test.clj
@@ -7,11 +7,13 @@
 
 (defn- hot-node
   []
-  {:bthread->bid {:watcher {:hot true}}})
+  {:bthread->bid {:watcher {:hot true}}
+   :hot true})
 
 (defn- cold-node
   []
-  {:bthread->bid {:watcher {}}})
+  {:bthread->bid {:watcher {}}
+   :hot false})
 
 (defn- outgoing-edges
   [lts node-id event-type]
@@ -97,7 +99,7 @@
         (let [cycle-trace (trace-edges lts (:node-id violation) cycle-edges)]
           (is (= (:node-id violation) (:node-id cycle-trace)))
           (is (every? (fn [node-id]
-                        (liveness/hot? (get-in lts [:nodes node-id])))
+                        (:hot (get-in lts [:nodes node-id])))
                       (:nodes cycle-trace))))))))
 
 (deftest liveness-violation-path-and-cycle-compose-into-a-coherent-witness
@@ -112,8 +114,8 @@
                  (contains? violation :cycle-edges))
         (let [path-trace (trace-edges lts (:root lts) (:path-edges violation))
               cycle-trace (trace-edges lts (:node-id path-trace) (:cycle-edges violation))]
-          (is (= (:node-id violation) (:node-id path-trace)))
-          (is (= (:node-id violation) (:node-id cycle-trace)))
-          (is (every? (fn [node-id]
-                        (liveness/hot? (get-in lts [:nodes node-id])))
+           (is (= (:node-id violation) (:node-id path-trace)))
+           (is (= (:node-id violation) (:node-id cycle-trace)))
+           (is (every? (fn [node-id]
+                        (:hot (get-in lts [:nodes node-id])))
                       (rest (:nodes cycle-trace)))))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_cycle_witness_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_cycle_witness_test.clj
@@ -1,0 +1,119 @@
+(ns tech.thomascothran.pavlov.model.check.liveness-cycle-witness-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tech.thomascothran.pavlov.bthread :as b]
+            [tech.thomascothran.pavlov.event :as e]
+            [tech.thomascothran.pavlov.graph :as graph]
+            [tech.thomascothran.pavlov.model.check.liveness :as liveness]))
+
+(defn- hot-node
+  []
+  {:bthread->bid {:watcher {:hot true}}})
+
+(defn- cold-node
+  []
+  {:bthread->bid {:watcher {}}})
+
+(defn- outgoing-edges
+  [lts node-id event-type]
+  (into []
+        (filter (fn [{:keys [from event]}]
+                  (and (= node-id from)
+                       (= event-type (e/type event)))))
+        (:edges lts)))
+
+(defn- trace-edges
+  [lts start-node-id witness-edges]
+  (reduce (fn [{:keys [node-id edges nodes]} edge]
+            (is (some #(= edge %) (:edges lts))
+                (str "Expected witness edge to be present in the LTS: " edge))
+            (is (= node-id (:from edge))
+                (str "Expected witness edge to continue from " node-id))
+            {:node-id (:to edge)
+             :edges (conj edges edge)
+             :nodes (conj nodes (:to edge))})
+          {:node-id start-node-id
+           :edges []
+           :nodes [start-node-id]}
+          witness-edges))
+
+(defn hot-cycle-bthreads
+  []
+  (let [looper (b/step
+                (fn [state event]
+                  (case (or state :waiting)
+                    :waiting (if (= :setup event)
+                               [:ping {:request #{:ping}
+                                       :hot true}]
+                               [:waiting {:wait-on #{:setup}}])
+                    :ping [:pong {:request #{:pong}
+                                  :hot true}]
+                    :pong [:ping {:request #{:ping}
+                                  :hot true}])))]
+    {:starter (b/bids [{:request #{:setup}}])
+     :looper looper}))
+
+(deftest liveness-violation-cycle-witness-returns-to-reported-node
+  (testing "A reported cycle witness closes back on the reported node"
+    (let [lts {:root :hot
+               :nodes {:hot (hot-node)}
+               :edges [{:from :hot
+                        :to :hot
+                        :event {:type :tick}}]}
+          violation (liveness/liveness-violation lts)
+          expected-cycle-edges [{:from :hot
+                                 :to :hot
+                                 :event {:type :tick}}]]
+      (is (= :hot (:node-id violation)))
+      (is (= [] (:path-edges violation)))
+      (is (= expected-cycle-edges (:cycle-edges violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (when-let [cycle-edges (:cycle-edges violation)]
+        (let [cycle-trace (trace-edges lts (:node-id violation) cycle-edges)]
+          (is (= (:node-id violation) (:node-id cycle-trace)))))
+      (is (= (get-in lts [:nodes (:node-id violation)]) (:state violation))))))
+
+(deftest liveness-violation-cycle-witness-stays-within-hot-region
+  (testing "Every node traversed by a reported cycle witness stays hot"
+    (let [lts {:root :root
+               :nodes {:root (cold-node)
+                       :entry (hot-node)
+                       :middle (hot-node)
+                       :cold-detour (cold-node)}
+               :edges [{:from :root :to :entry :event {:type :enter}}
+                       {:from :entry :to :cold-detour :event {:type :detour}}
+                       {:from :entry :to :middle :event {:type :cycle-a}}
+                       {:from :middle :to :entry :event {:type :cycle-b}}]}
+          violation (liveness/liveness-violation lts)
+          expected-path-edges [{:from :root :to :entry :event {:type :enter}}]
+          expected-cycle-edges [{:from :entry :to :middle :event {:type :cycle-a}}
+                                {:from :middle :to :entry :event {:type :cycle-b}}]]
+      (is (= :entry (:node-id violation)))
+      (is (= expected-path-edges (:path-edges violation)))
+      (is (= expected-cycle-edges (:cycle-edges violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (when-let [cycle-edges (:cycle-edges violation)]
+        (let [cycle-trace (trace-edges lts (:node-id violation) cycle-edges)]
+          (is (= (:node-id violation) (:node-id cycle-trace)))
+          (is (every? (fn [node-id]
+                        (liveness/hot? (get-in lts [:nodes node-id])))
+                      (:nodes cycle-trace))))))))
+
+(deftest liveness-violation-path-and-cycle-compose-into-a-coherent-witness
+  (testing "The root path and cycle witness compose into one coherent execution"
+    (let [lts (graph/->lts (hot-cycle-bthreads))
+          violation (liveness/liveness-violation lts)]
+      (is (some? (:cycle-edges violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (= (get-in lts [:nodes (:node-id violation)]) (:state violation)))
+      (when (and (contains? violation :path-edges)
+                 (contains? violation :cycle-edges))
+        (let [path-trace (trace-edges lts (:root lts) (:path-edges violation))
+              cycle-trace (trace-edges lts (:node-id path-trace) (:cycle-edges violation))]
+          (is (= (:node-id violation) (:node-id path-trace)))
+          (is (= (:node-id violation) (:node-id cycle-trace)))
+          (is (every? (fn [node-id]
+                        (liveness/hot? (get-in lts [:nodes node-id])))
+                      (rest (:nodes cycle-trace)))))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_deadlock_edge_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_deadlock_edge_test.clj
@@ -26,10 +26,14 @@
 
 (def converged-hot-deadlock-lts
   {:root :root
-   :nodes {:root {:bthread->bid {:chooser {:request #{:a :b}}}}
-           :left {:bthread->bid {:step {:request #{:merge-left}}}}
-           :right {:bthread->bid {:step {:request #{:merge-right}}}}
-           :merged {:bthread->bid {:hotter {:hot true}}}}
+   :nodes {:root {:bthread->bid {:chooser {:request #{:a :b}}}
+                  :hot false}
+           :left {:bthread->bid {:step {:request #{:merge-left}}}
+                  :hot false}
+           :right {:bthread->bid {:step {:request #{:merge-right}}}
+                   :hot false}
+           :merged {:bthread->bid {:hotter {:hot true}}
+                    :hot true}}
    :edges [{:from :root :to :left :event :a}
            {:from :root :to :right :event :b}
            {:from :left :to :merged :event :merge-left}
@@ -38,7 +42,8 @@
 (deftest liveness-violation-root-hot-deadlock-uses-empty-path-witness
   (testing "A hot deadlock at the root reports an empty root-to-node witness"
     (let [lts {:root :root
-               :nodes {:root {:bthread->bid {:watcher {:hot true}}}}
+               :nodes {:root {:bthread->bid {:watcher {:hot true}}
+                              :hot true}}
                :edges []}
           violation (liveness/liveness-violation lts)]
       (is (= :root (:node-id violation)))
@@ -66,7 +71,7 @@
              (path-edge-destination converged-hot-deadlock-lts (:path-edges violation))))
       (is (contains? (liveness/deadlock-node-ids converged-hot-deadlock-lts)
                      (:node-id violation)))
-      (is (liveness/hot? (:state violation)))
+      (is (:hot (:state violation)))
       (is (not (contains? violation :cycle-edges)))
       (is (not (contains? violation :path)))
       (is (not (contains? violation :cycle))))))
@@ -74,9 +79,12 @@
 (deftest liveness-violation-deadlock-witness-does-not-use-empty-path-for-non-root-node
   (testing "A reported deadlock witness must reach its node, and an empty path is only valid at the root"
     (let [lts {:root :root
-               :nodes {:root {:bthread->bid {}}
-                       :reachable {:bthread->bid {}}
-                       :unreachable-hot {:bthread->bid {:watcher {:hot true}}}}
+               :nodes {:root {:bthread->bid {}
+                              :hot false}
+                       :reachable {:bthread->bid {}
+                                   :hot false}
+                       :unreachable-hot {:bthread->bid {:watcher {:hot true}}
+                                         :hot true}}
                :edges [{:from :root :to :reachable :event :go}]}
           violation (liveness/liveness-violation lts)]
       (is (or (nil? violation)
@@ -84,4 +92,4 @@
                  (path-edge-destination lts (:path-edges violation)))))
       (is (or (nil? violation)
               (not (and (empty? (:path-edges violation))
-                         (not= (:root lts) (:node-id violation)))))))))
+                        (not= (:root lts) (:node-id violation)))))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_deadlock_edge_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_deadlock_edge_test.clj
@@ -1,0 +1,87 @@
+(ns tech.thomascothran.pavlov.model.check.liveness-deadlock-edge-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tech.thomascothran.pavlov.bthread :as b]
+            [tech.thomascothran.pavlov.graph :as graph]
+            [tech.thomascothran.pavlov.model.check.liveness :as liveness]))
+
+(defn path-edge-destination
+  [lts path-edges]
+  (reduce (fn [node-id {:keys [from to] :as edge}]
+            (when (and (= from node-id)
+                       (some #(= edge %)
+                             (:edges lts)))
+              to))
+          (:root lts)
+          path-edges))
+
+(defn exit-hot-then-deadlock-bthreads
+  []
+  {:starter (b/bids [{:request #{:setup}}])
+   :obligation (b/bids [{:wait-on #{:setup}}
+                        {:request #{:cooldown}
+                         :hot true}
+                        {}])
+   :driver (b/bids [{:wait-on #{:setup}}
+                    {:request #{:cooldown}}])})
+
+(def converged-hot-deadlock-lts
+  {:root :root
+   :nodes {:root {:bthread->bid {:chooser {:request #{:a :b}}}}
+           :left {:bthread->bid {:step {:request #{:merge-left}}}}
+           :right {:bthread->bid {:step {:request #{:merge-right}}}}
+           :merged {:bthread->bid {:hotter {:hot true}}}}
+   :edges [{:from :root :to :left :event :a}
+           {:from :root :to :right :event :b}
+           {:from :left :to :merged :event :merge-left}
+           {:from :right :to :merged :event :merge-right}]})
+
+(deftest liveness-violation-root-hot-deadlock-uses-empty-path-witness
+  (testing "A hot deadlock at the root reports an empty root-to-node witness"
+    (let [lts {:root :root
+               :nodes {:root {:bthread->bid {:watcher {:hot true}}}}
+               :edges []}
+          violation (liveness/liveness-violation lts)]
+      (is (= :root (:node-id violation)))
+      (is (= [] (:path-edges violation)))
+      (is (not (contains? violation :cycle-edges)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (= (get-in lts [:nodes :root]) (:state violation))))))
+
+(deftest liveness-violation-ignores-deadlock-after-leaving-hot-region
+  (testing "A deadlock reached only after exiting the hot region is not a liveness violation"
+    (let [lts (graph/->lts (exit-hot-then-deadlock-bthreads))]
+      (is (nil? (liveness/liveness-violation lts))))))
+
+(deftest liveness-violation-deadlock-witness-stays-consistent-after-convergence
+  (testing "A reported deadlock witness keeps node, state, and path in sync after paths converge"
+    (let [violation (liveness/liveness-violation converged-hot-deadlock-lts)]
+      (is (= :merged (:node-id violation)))
+      (is (= (get-in converged-hot-deadlock-lts [:nodes (:node-id violation)])
+             (:state violation)))
+      (is (= [{:from :root :to :left :event :a}
+              {:from :left :to :merged :event :merge-left}]
+             (:path-edges violation)))
+      (is (= (:node-id violation)
+             (path-edge-destination converged-hot-deadlock-lts (:path-edges violation))))
+      (is (contains? (liveness/deadlock-node-ids converged-hot-deadlock-lts)
+                     (:node-id violation)))
+      (is (liveness/hot? (:state violation)))
+      (is (not (contains? violation :cycle-edges)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle))))))
+
+(deftest liveness-violation-deadlock-witness-does-not-use-empty-path-for-non-root-node
+  (testing "A reported deadlock witness must reach its node, and an empty path is only valid at the root"
+    (let [lts {:root :root
+               :nodes {:root {:bthread->bid {}}
+                       :reachable {:bthread->bid {}}
+                       :unreachable-hot {:bthread->bid {:watcher {:hot true}}}}
+               :edges [{:from :root :to :reachable :event :go}]}
+          violation (liveness/liveness-violation lts)]
+      (is (or (nil? violation)
+              (= (:node-id violation)
+                 (path-edge-destination lts (:path-edges violation)))))
+      (is (or (nil? violation)
+              (not (and (empty? (:path-edges violation))
+                         (not= (:root lts) (:node-id violation)))))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_graph_contract_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_graph_contract_test.clj
@@ -1,0 +1,120 @@
+(ns tech.thomascothran.pavlov.model.check.liveness-graph-contract-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tech.thomascothran.pavlov.bthread :as b]
+            [tech.thomascothran.pavlov.event :as e]
+            [tech.thomascothran.pavlov.graph :as graph]
+            [tech.thomascothran.pavlov.model.check.liveness :as liveness]))
+
+(defn- same-type-terminal-and-nonterminal-branches-bthreads
+  []
+  {:chooser (b/bids [{:request #{{:type :done}
+                                  {:type :done :terminal true}}}])
+   :watcher (b/bids [{:wait-on #{{:type :done}
+                                 {:type :done :terminal true}}}
+                     {:hot true}])})
+
+(defn- converging-hot-cycle-bthreads
+  []
+  {:chooser (b/bids [{:request #{:left :right}}])
+   :converger (b/bids [{:wait-on #{:left :right}}
+                       {:request #{:ping}
+                        :hot true}])
+   :looper (b/step
+            (fn [state event]
+              (case (or state :waiting)
+                :waiting (if (= :ping event)
+                           [:pong {:request #{:pong}
+                                   :hot true}]
+                           [:waiting {:wait-on #{:ping}}])
+                :pong [:ping {:request #{:ping}
+                              :hot true}]
+                :ping [:pong {:request #{:pong}
+                              :hot true}])))}
+  )
+
+(defn- trace-edges
+  [lts start-node-id witness-edges]
+  (reduce (fn [{:keys [node-id visited-node-ids]} edge]
+            (is (some #(= edge %) (:edges lts))
+                (str "Expected witness edge to be present in the LTS: " edge))
+            (is (= node-id (:from edge))
+                (str "Expected witness edge to continue from " node-id))
+            {:node-id (:to edge)
+             :visited-node-ids (conj visited-node-ids (:to edge))})
+          {:node-id start-node-id
+           :visited-node-ids []}
+          witness-edges))
+
+(deftest graph-layer-contract-keeps-terminal-target-distinct-from-nonterminal-peer
+  (testing "Terminal and non-terminal routes with the same observable event type remain distinguishable"
+    (let [lts (graph/->lts (same-type-terminal-and-nonterminal-branches-bthreads))
+           terminal-edge (first (filter #(get-in % [:event :terminal]) (:edges lts)))
+           nonterminal-edge (first (remove #(get-in % [:event :terminal]) (:edges lts)))
+          violation (liveness/liveness-violation lts)]
+      (is (some? terminal-edge))
+      (is (some? nonterminal-edge))
+      (is (not= (:to terminal-edge) (:to nonterminal-edge))
+          "Graph should keep terminal-target identity distinct from its non-terminal peer")
+      (is (= (get-in lts [:nodes (:to terminal-edge)])
+             (get-in lts [:nodes (:to nonterminal-edge)]))
+          "The distinction should survive even when the node payloads otherwise match")
+      (is (= (:to terminal-edge) (:node-id violation))
+          "Liveness witness should point at the hot terminal target")
+      (is (= (get-in lts [:nodes (:node-id violation)])
+             (:state violation)))
+      (is (= [terminal-edge] (:path-edges violation)))
+      (is (not (contains? violation :cycle-edges)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle))))))
+
+(deftest graph-layer-contract-cycle-witness-stays-coherent-after-convergence
+  (testing "A graph->lts witness stays coherent when two paths converge before a hot cycle"
+    (let [lts (graph/->lts (converging-hot-cycle-bthreads))
+           left-edge (first (filter #(= :left (:event %)) (:edges lts)))
+           right-edge (first (filter #(= :right (:event %)) (:edges lts)))
+           violation (liveness/liveness-violation lts)]
+      (is (= (:to left-edge) (:to right-edge))
+          "The two entry branches should merge before the hot strongly connected region")
+      (is (= (get-in lts [:nodes (:node-id violation)])
+             (:state violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (when (and (contains? violation :path-edges)
+                 (contains? violation :cycle-edges))
+        (let [path-trace (trace-edges lts (:root lts) (:path-edges violation))
+              cycle-trace (trace-edges lts (:node-id violation) (:cycle-edges violation))]
+          (is (= (:node-id violation) (:node-id path-trace))
+              "Witness path should reach the reported cycle entry node")
+          (is (= (:node-id violation) (:node-id cycle-trace))
+              "Witness cycle should close back on the reported cycle entry node")
+          (is (every? #(liveness/hot? (get-in lts [:nodes %]))
+                      (cons (:node-id violation) (:visited-node-ids cycle-trace)))
+              "Witness cycle should stay within the hot region"))))))
+
+(deftest graph-layer-contract-cycle-witness-survives-edge-reordering
+  (testing "Reordering graph edges may change witness selection, but should not break cycle correctness"
+    (let [lts (graph/->lts (converging-hot-cycle-bthreads))
+           reversed-lts (update lts :edges #(vec (reverse %)))]
+      (doseq [[label candidate-lts] [[:original lts]
+                                     [:reversed reversed-lts]]]
+        (let [violation (liveness/liveness-violation candidate-lts)]
+          (is (some? (:cycle-edges violation))
+              (str label " graph should still report a hot cycle violation"))
+          (is (not (contains? violation :path))
+              (str label " graph should drop the old :path witness key"))
+          (is (not (contains? violation :cycle))
+              (str label " graph should drop the old :cycle witness key"))
+          (is (= (get-in candidate-lts [:nodes (:node-id violation)])
+                 (:state violation))
+              (str label " witness state should match the reported node"))
+          (when (and (contains? violation :path-edges)
+                     (contains? violation :cycle-edges))
+            (let [path-trace (trace-edges candidate-lts (:root candidate-lts) (:path-edges violation))
+                  cycle-trace (trace-edges candidate-lts (:node-id violation) (:cycle-edges violation))]
+              (is (= (:node-id violation) (:node-id path-trace))
+                  (str label " path witness should still reach the reported node"))
+              (is (= (:node-id violation) (:node-id cycle-trace))
+                  (str label " cycle witness should still close after edge reordering"))
+              (is (every? #(liveness/hot? (get-in candidate-lts [:nodes %]))
+                          (cons (:node-id violation) (:visited-node-ids cycle-trace)))
+                  (str label " cycle witness should remain entirely hot")))))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_graph_contract_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_graph_contract_test.clj
@@ -87,7 +87,7 @@
               "Witness path should reach the reported cycle entry node")
           (is (= (:node-id violation) (:node-id cycle-trace))
               "Witness cycle should close back on the reported cycle entry node")
-          (is (every? #(liveness/hot? (get-in lts [:nodes %]))
+          (is (every? #(:hot (get-in lts [:nodes %]))
                       (cons (:node-id violation) (:visited-node-ids cycle-trace)))
               "Witness cycle should stay within the hot region"))))))
 
@@ -113,8 +113,8 @@
                   cycle-trace (trace-edges candidate-lts (:node-id violation) (:cycle-edges violation))]
               (is (= (:node-id violation) (:node-id path-trace))
                   (str label " path witness should still reach the reported node"))
-              (is (= (:node-id violation) (:node-id cycle-trace))
-                  (str label " cycle witness should still close after edge reordering"))
-              (is (every? #(liveness/hot? (get-in candidate-lts [:nodes %]))
-                          (cons (:node-id violation) (:visited-node-ids cycle-trace)))
-                  (str label " cycle witness should remain entirely hot")))))))))
+               (is (= (:node-id violation) (:node-id cycle-trace))
+                   (str label " cycle witness should still close after edge reordering"))
+               (is (every? #(:hot (get-in candidate-lts [:nodes %]))
+                           (cons (:node-id violation) (:visited-node-ids cycle-trace)))
+                   (str label " cycle witness should remain entirely hot")))))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_terminal_witness_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_terminal_witness_test.clj
@@ -12,9 +12,12 @@
 (deftest liveness-violation-terminal-witness-uses-violating-edge-when-target-has-another-incoming-path
   (testing "The reported witness should include the terminal event that established the violation"
     (let [lts {:root :r
-               :nodes {:r {:bthread->bid {:t {}}}
-                       :y {:bthread->bid {:t {}}}
-                       :x {:bthread->bid {:t {:hot true}}}}
+               :nodes {:r {:bthread->bid {:t {}}
+                           :hot false}
+                       :y {:bthread->bid {:t {}}
+                           :hot false}
+                       :x {:bthread->bid {:t {:hot true}}
+                           :hot true}}
                :edges [{:from :r :to :x :event :a}
                        {:from :r :to :y :event :b}
                        {:from :y :to :x :event (terminal-event :done)}]}
@@ -31,10 +34,14 @@
 (deftest liveness-violation-terminal-witness-uses-the-scanned-terminal-edge-when-multiple-terminal-edges-hit-the-same-target
   (testing "The witness should preserve which terminal edge was selected as the violation witness"
     (let [lts {:root :r
-               :nodes {:r {:bthread->bid {:t {}}}
-                       :a {:bthread->bid {:t {}}}
-                       :b {:bthread->bid {:t {}}}
-                       :x {:bthread->bid {:t {:hot true}}}}
+               :nodes {:r {:bthread->bid {:t {}}
+                           :hot false}
+                       :a {:bthread->bid {:t {}}
+                           :hot false}
+                       :b {:bthread->bid {:t {}}
+                           :hot false}
+                       :x {:bthread->bid {:t {:hot true}}
+                           :hot true}}
                :edges [{:from :r :to :a :event :a}
                        {:from :r :to :b :event :b}
                        {:from :b :to :x :event (terminal-event :done-b)}

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_terminal_witness_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_terminal_witness_test.clj
@@ -1,0 +1,68 @@
+(ns tech.thomascothran.pavlov.model.check.liveness-terminal-witness-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tech.thomascothran.pavlov.bthread :as b]
+            [tech.thomascothran.pavlov.graph :as graph]
+            [tech.thomascothran.pavlov.model.check.liveness :as liveness]))
+
+(defn- terminal-event
+  [event-type]
+  {:type event-type
+   :terminal true})
+
+(deftest liveness-violation-terminal-witness-uses-violating-edge-when-target-has-another-incoming-path
+  (testing "The reported witness should include the terminal event that established the violation"
+    (let [lts {:root :r
+               :nodes {:r {:bthread->bid {:t {}}}
+                       :y {:bthread->bid {:t {}}}
+                       :x {:bthread->bid {:t {:hot true}}}}
+               :edges [{:from :r :to :x :event :a}
+                       {:from :r :to :y :event :b}
+                       {:from :y :to :x :event (terminal-event :done)}]}
+          violation (liveness/liveness-violation lts)]
+      (is (= :x (:node-id violation)))
+      (is (= [{:from :r :to :y :event :b}
+              {:from :y :to :x :event (terminal-event :done)}]
+             (:path-edges violation)))
+      (is (not (contains? violation :cycle-edges)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (= (get-in lts [:nodes :x]) (:state violation))))))
+
+(deftest liveness-violation-terminal-witness-uses-the-scanned-terminal-edge-when-multiple-terminal-edges-hit-the-same-target
+  (testing "The witness should preserve which terminal edge was selected as the violation witness"
+    (let [lts {:root :r
+               :nodes {:r {:bthread->bid {:t {}}}
+                       :a {:bthread->bid {:t {}}}
+                       :b {:bthread->bid {:t {}}}
+                       :x {:bthread->bid {:t {:hot true}}}}
+               :edges [{:from :r :to :a :event :a}
+                       {:from :r :to :b :event :b}
+                       {:from :b :to :x :event (terminal-event :done-b)}
+                       {:from :a :to :x :event (terminal-event :done-a)}]}
+          violation (liveness/liveness-violation lts)]
+      (is (= :x (:node-id violation)))
+      (is (= [{:from :r :to :b :event :b}
+              {:from :b :to :x :event (terminal-event :done-b)}]
+             (:path-edges violation)))
+      (is (not (contains? violation :cycle-edges)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (= (get-in lts [:nodes :x]) (:state violation))))))
+
+(deftest liveness-violation-terminal-witness-characterization-for-generated-lts
+  (testing "A generated hot terminal violation still reports a witness ending with the terminal event"
+    (let [lts (graph/->lts
+               {:finisher (b/bids [{:request #{(terminal-event :done)}}])
+                 :watcher (b/bids [{:wait-on #{:done}}
+                                   {:hot true}])})
+          violation (liveness/liveness-violation lts)]
+      (is (some? violation))
+      (is (= [(first (:edges lts))]
+             (:path-edges violation)))
+      (is (= :done
+             (-> violation :path-edges last :event :type)))
+      (is (not (contains? violation :cycle-edges)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (= (get-in lts [:nodes (:node-id violation)])
+             (:state violation))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_test.clj
@@ -1,0 +1,113 @@
+(ns tech.thomascothran.pavlov.model.check.liveness-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [tech.thomascothran.pavlov.bthread :as b]
+            [tech.thomascothran.pavlov.graph :as graph]
+            [tech.thomascothran.pavlov.model.check.liveness :as liveness]))
+
+(defn hot-terminal-bthreads
+  []
+  {:finisher (b/bids [{:request #{{:type :done
+                                   :terminal true}}}])
+   :watcher (b/bids [{:wait-on #{:done}}
+                     {:hot true}])})
+
+(defn hot-deadlock-bthreads
+  []
+  {:starter (b/bids [{:request #{:setup}}])
+   :obligation (b/bids [{:wait-on #{:setup}}
+                        {:hot true}])})
+
+(defn hot-cycle-bthreads
+  []
+  (let [looper (b/step
+                (fn [state event]
+                  (case (or state :waiting)
+                    :waiting (if (= :setup event)
+                               [:ping {:request #{:ping}
+                                       :hot true}]
+                               [:waiting {:wait-on #{:setup}}])
+                    :ping [:pong {:request #{:pong}
+                                  :hot true}]
+                    :pong [:ping {:request #{:ping}
+                                  :hot true}])))]
+    {:starter (b/bids [{:request #{:setup}}])
+     :looper looper}))
+
+(defn cold-node-breaks-cycle-bthreads
+  []
+  (let [looper (b/step
+                (fn [state event]
+                  (case (or state :waiting)
+                    :waiting (if (= :setup event)
+                               [:hot {:request #{:ping}
+                                      :hot true}]
+                               [:waiting {:wait-on #{:setup}}])
+                    :hot [:cold {:request #{:pong}}]
+                    :cold [:hot {:request #{:ping}
+                                 :hot true}])))]
+    {:starter (b/bids [{:request #{:setup}}])
+     :looper looper}))
+
+(deftest liveness-violation-detects-hot-terminal-path
+  (testing "Hot terminal event reports the terminal event in the witness path"
+    (let [lts (graph/->lts (hot-terminal-bthreads))
+          violation (liveness/liveness-violation lts)]
+      (is (= [:done] (:path violation)))
+      (is (nil? (:cycle violation)))
+      (is (liveness/hot? (:state violation))))))
+
+(deftest liveness-violation-detects-hot-deadlock
+  (testing "Hot deadlock reports the path to the stuck hot node"
+    (let [lts (graph/->lts (hot-deadlock-bthreads))
+          violation (liveness/liveness-violation lts)]
+      (is (= [:setup] (:path violation)))
+      (is (nil? (:cycle violation)))
+      (is (liveness/hot? (:state violation))))))
+
+(deftest liveness-violation-detects-hot-cycle-with-cold-prefix
+  (testing "Hot cycle detection returns a cold-prefix path and a hot-only cycle witness"
+    (let [lts (graph/->lts (hot-cycle-bthreads))
+          violation (liveness/liveness-violation lts)]
+      (is (= [:setup] (:path violation)))
+      (is (= [:ping :pong] (:cycle violation)))
+      (is (liveness/hot? (:state violation))))))
+
+(deftest liveness-violation-ignores-cycles-that-leave-hot-region
+  (testing "A cycle that passes through a cold node is not a hot liveness violation"
+    (let [lts (graph/->lts (cold-node-breaks-cycle-bthreads))]
+      (is (nil? (liveness/liveness-violation lts))))))
+
+(deftest liveness-violation-does-not-flag-terminal-event-that-exits-hot-region
+  (testing "A terminal event that leaves the hot region should not be reported as a liveness violation"
+    (let [lts (graph/->lts
+               {:finisher
+                (b/bids [{:request #{:start}}
+                         {:request #{{:type :done
+                                      :terminal true}}
+                          :hot true}])})]
+      (is (nil? (liveness/liveness-violation lts))))))
+
+(deftest liveness-violation-flags-hot-terminal-target-node
+  (testing "A terminal edge whose target node is hot should be reported as a liveness violation"
+    (let [lts (graph/->lts
+               {:finisher (b/bids [{:request #{{:type :done
+                                                :terminal true}}}])
+                :watcher (b/bids [{:wait-on #{:done}}
+                                  {:hot true}])})
+          violation (liveness/liveness-violation lts)]
+      (is (some? violation))
+      (is (= [:done] (:path violation)))
+      (is (nil? (:cycle violation)))
+      (is (liveness/hot? (:state violation))))))
+
+(deftest liveness-violation-handles-non-comparable-event-types
+  (testing "Liveness checking should not crash when witness paths contain non-comparable event types"
+    (let [event-a {:type {:branch :a}}
+          event-b {:type {:branch :b}}
+          lts (graph/->lts
+               {:starter (b/bids [{:request #{event-a event-b}}])
+                :hot-a (b/bids [{:wait-on #{event-a}}
+                                {:hot true}])
+                :hot-b (b/bids [{:wait-on #{event-b}}
+                                {:hot true}])})]
+      (is (some? (liveness/liveness-violation lts))))))

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_test.clj
@@ -60,7 +60,7 @@
       (is (not (contains? violation :path)))
       (is (not (contains? violation :cycle)))
       (is (not (contains? violation :cycle-edges)))
-      (is (liveness/hot? (:state violation))))))
+      (is (:hot (:state violation))))))
 
 (deftest liveness-violation-detects-hot-deadlock
   (testing "Hot deadlock reports the path to the stuck hot node"
@@ -74,7 +74,7 @@
       (is (not (contains? violation :path)))
       (is (not (contains? violation :cycle)))
       (is (not (contains? violation :cycle-edges)))
-      (is (liveness/hot? (:state violation))))))
+      (is (:hot (:state violation))))))
 
 (deftest liveness-violation-detects-hot-cycle-with-cold-prefix
   (testing "Hot cycle detection returns a cold-prefix path and a hot-only cycle witness"
@@ -88,7 +88,7 @@
              (:state violation)))
       (is (not (contains? violation :path)))
       (is (not (contains? violation :cycle)))
-      (is (liveness/hot? (:state violation))))))
+      (is (:hot (:state violation))))))
 
 (deftest liveness-violation-ignores-cycles-that-leave-hot-region
   (testing "A cycle that passes through a cold node is not a hot liveness violation"
@@ -122,7 +122,7 @@
       (is (not (contains? violation :path)))
       (is (not (contains? violation :cycle)))
       (is (not (contains? violation :cycle-edges)))
-      (is (liveness/hot? (:state violation))))))
+      (is (:hot (:state violation))))))
 
 (deftest liveness-violation-handles-non-comparable-event-types
   (testing "Liveness checking should not crash when witness paths contain non-comparable event types"

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check/liveness_test.clj
@@ -51,25 +51,43 @@
 (deftest liveness-violation-detects-hot-terminal-path
   (testing "Hot terminal event reports the terminal event in the witness path"
     (let [lts (graph/->lts (hot-terminal-bthreads))
+          [terminal-edge] (:edges lts)
           violation (liveness/liveness-violation lts)]
-      (is (= [:done] (:path violation)))
-      (is (nil? (:cycle violation)))
+      (is (= (:to terminal-edge) (:node-id violation)))
+      (is (= [terminal-edge] (:path-edges violation)))
+      (is (= (get-in lts [:nodes (:to terminal-edge)])
+             (:state violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (not (contains? violation :cycle-edges)))
       (is (liveness/hot? (:state violation))))))
 
 (deftest liveness-violation-detects-hot-deadlock
   (testing "Hot deadlock reports the path to the stuck hot node"
     (let [lts (graph/->lts (hot-deadlock-bthreads))
+          [setup-edge] (:edges lts)
           violation (liveness/liveness-violation lts)]
-      (is (= [:setup] (:path violation)))
-      (is (nil? (:cycle violation)))
+      (is (= (:to setup-edge) (:node-id violation)))
+      (is (= [setup-edge] (:path-edges violation)))
+      (is (= (get-in lts [:nodes (:to setup-edge)])
+             (:state violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (not (contains? violation :cycle-edges)))
       (is (liveness/hot? (:state violation))))))
 
 (deftest liveness-violation-detects-hot-cycle-with-cold-prefix
   (testing "Hot cycle detection returns a cold-prefix path and a hot-only cycle witness"
     (let [lts (graph/->lts (hot-cycle-bthreads))
+          [setup-edge ping-edge pong-edge] (:edges lts)
           violation (liveness/liveness-violation lts)]
-      (is (= [:setup] (:path violation)))
-      (is (= [:ping :pong] (:cycle violation)))
+      (is (= (:to setup-edge) (:node-id violation)))
+      (is (= [setup-edge] (:path-edges violation)))
+      (is (= [ping-edge pong-edge] (:cycle-edges violation)))
+      (is (= (get-in lts [:nodes (:to setup-edge)])
+             (:state violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
       (is (liveness/hot? (:state violation))))))
 
 (deftest liveness-violation-ignores-cycles-that-leave-hot-region
@@ -94,10 +112,16 @@
                                                 :terminal true}}}])
                 :watcher (b/bids [{:wait-on #{:done}}
                                   {:hot true}])})
+          [terminal-edge] (:edges lts)
           violation (liveness/liveness-violation lts)]
       (is (some? violation))
-      (is (= [:done] (:path violation)))
-      (is (nil? (:cycle violation)))
+      (is (= (:to terminal-edge) (:node-id violation)))
+      (is (= [terminal-edge] (:path-edges violation)))
+      (is (= (get-in lts [:nodes (:to terminal-edge)])
+             (:state violation)))
+      (is (not (contains? violation :path)))
+      (is (not (contains? violation :cycle)))
+      (is (not (contains? violation :cycle-edges)))
       (is (liveness/hot? (:state violation))))))
 
 (deftest liveness-violation-handles-non-comparable-event-types

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
@@ -446,28 +446,29 @@
 (deftest livelock-with-terminating-branch
   (testing "Livelock detected even when one branch terminates"
     ;; Create a scenario where:
-    ;; - Bthread 1 requests :terminate (terminal event)
-    ;; - Bthread 2 requests :loop-start, which leads to infinite ping-pong
+    ;; - One branch takes a terminal :terminate event
+    ;; - Another branch takes :loop-start, which leads to infinite ping-pong
     ;; At the first sync point, model checker explores both branches.
     ;; The :terminate branch leads to termination (OK).
     ;; The :loop-start branch leads to livelock (VIOLATION).
-    (let [terminating-branch
-          (b/bids [{:request #{{:type :terminate :terminal true}}}])
+    (let [chooser
+          (b/bids [{:request #{:loop-start
+                              {:type :terminate :terminal true}}}])
 
           looping-branch
           (b/step
-           (fn [state event]
-             (case (or state :waiting)
-               :waiting (if (= :loop-start event)
-                          [:ping {:request #{:ping}}]
-                          [:waiting {:request #{:loop-start}}])
-               :ping [:pong {:request #{:pong}}]
-               :pong [:ping {:request #{:ping}}])))
+            (fn [state event]
+              (case (or state :waiting)
+                :waiting (if (= :loop-start event)
+                           [:ping {:request #{:ping}}]
+                           [:waiting {:wait-on #{:loop-start}}])
+                :ping [:pong {:request #{:pong}}]
+                :pong [:ping {:request #{:ping}}])))
 
           result (check/check
-                  {:bthreads {:terminating terminating-branch
-                              :looping looping-branch}
-                   :check-livelock? true})]
+                  {:bthreads {:chooser chooser
+                               :looping looping-branch}
+                    :check-livelock? true})]
       (is (some? result)
           "Should detect a livelock even though one branch terminates")
       (when result
@@ -509,6 +510,30 @@
         ;; New format: :truncated is a boolean flag
         (is (true? (:truncated result))
             "Should have :truncated true when max-nodes exceeded")))))
+
+(deftest truncation-suppresses-liveness-violations
+  (testing "Should not report liveness violations from a truncated graph"
+    (let [worker (b/step
+                  (fn [state _event]
+                    (let [n (or state 0)]
+                      (if (< n 5)
+                        [(inc n) {:request #{(keyword (str "event-" n))}}]
+                        [(inc n) {:request #{:payment}}]))))
+          result (check/check
+                  {:bthreads {:worker worker}
+                   :liveness {:payment-required
+                              {:quantifier :universal
+                               :eventually #{:payment}}}
+                   :max-nodes 2})]
+      (is (some? result)
+          "Should still return a truncation result")
+      (when result
+        (is (true? (:truncated result))
+            "Should mark the result as truncated")
+        (is (nil? (:liveness-violations result))
+            "Should suppress liveness violations when exploration is truncated")
+        (is (nil? (:deadlocks result))
+            "Should suppress deadlocks when exploration is truncated")))))
 
 (deftest universal-liveness-violation-on-terminating-path
   (testing "Universal liveness property violated when path terminates without satisfying predicate"

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
@@ -304,12 +304,9 @@
                     (b/bids [{:wait-on #{:b}}
                              {:request #{{:type :b-confirmed
                                           :terminal true}}}])}
-          liveness {:a-confirmed {:quantifier :existential
-                                  :eventually #{:a-confirmed}}
-                    :b-confirmed {:quantifier :existential
-                                  :eventually #{:b-confirmed}}}
           result (check/check {:bthreads bthreads
-                               :liveness liveness})]
+                               :possible #{:a-confirmed
+                                           :b-confirmed}})]
       (is (nil? result)))))
 
 (deftest map-bthreads-preserve-equal-priority-branching
@@ -350,22 +347,19 @@
                          {:request #{{:type :b-confirmed :terminal true}}
                           :block #{:a}}
                          {:block #{:a}}])]])]
-      (let [liveness {:a-confirmed {:quantifier :existential
-                                    :eventually #{:a-confirmed}}
-                      :b-confirmed {:quantifier :existential
-                                    :eventually #{:b-confirmed}}}
-            map-result (check/check {:bthreads (make-map-bthreads)
-                                     :liveness liveness
+      (let [map-result (check/check {:bthreads (make-map-bthreads)
+                                     :possible #{:a-confirmed
+                                                 :b-confirmed}
                                      :check-deadlock? false})
             ordered-result (check/check {:bthreads (make-ordered-bthreads)
-                                         :liveness liveness
+                                         :possible #{:a-confirmed
+                                                     :b-confirmed}
                                          :check-deadlock? false})]
         (is (nil? map-result)
             "Map input should keep :request-a and :request-b at equal priority, so both confirmations are reachable")
-        (is (= [{:property :b-confirmed
-                 :quantifier :existential}]
-               (:liveness-violations ordered-result))
-            "Ordered input should only follow :request-a first, leaving :b-confirmed unreachable")))))
+        (is ordered-result)
+        (is (= #{:b-confirmed}
+               (get ordered-result :impossible)))))))
 
 (deftest no-livelock-when-program-terminates
   (testing "Program that terminates normally should not be flagged as livelock"
@@ -522,13 +516,13 @@
     ;; A bthread that terminates immediately without doing anything else
     ;; The liveness property requires :payment to occur on ALL paths
     ;; Expected: liveness violation because no :payment event occurred
-     (let [result (check/check
+    (let [result (check/check
                   {:bthreads {:terminate-immediately
                               (b/bids [{:request #{{:type :done :terminal true}}}])}
                    :liveness
-                    {:payment-required
-                     {:quantifier :universal
-                      :eventually #{:payment}}}})]
+                   {:payment-required
+                    {:quantifier :universal
+                     :eventually #{:payment}}}})]
 
       ;; The test SHOULD fail because :liveness is not implemented yet
       ;; Either result will be nil (no violation detected) OR
@@ -557,14 +551,14 @@
     ;; A bthread that requests :payment first, then terminates
     ;; The liveness property requires :payment to occur on ALL paths
     ;; Expected: nil (no violation) because :payment occurred before termination
-     (let [result (check/check
+    (let [result (check/check
                   {:bthreads {:payment-then-terminate
                               (b/bids [{:request #{:payment}}
                                        {:request #{{:type :done :terminal true}}}])}
                    :liveness
-                    {:payment-required
-                     {:quantifier :universal
-                      :eventually #{:payment}}}})]
+                   {:payment-required
+                    {:quantifier :universal
+                     :eventually #{:payment}}}})]
 
       ;; Should return nil - no violation
       (is (nil? result)
@@ -679,9 +673,9 @@
           (is (= #{:payment :ack} (set (:cycle livelock)))
               "Cycle should contain :payment and :ack events"))))))
 
-(deftest existential-liveness-satisfied-one-path
-  (testing "Existential liveness property satisfied when ANY path satisfies it"
-    ;; This is Cycle 2.6: existential quantifier with one satisfying path
+(deftest possible-check-satisfied-one-path
+  (testing "Possible check is satisfied when ANY path contains the event"
+    ;; This is Cycle 2.6: possibility check with one satisfying path
     ;; Two branches:
     ;; - One branch requests :failure then terminates (no :payment)
     ;; - Other branch requests :payment then terminates
@@ -701,26 +695,14 @@
           result (check/check
                   {:bthreads {:failure-branch failure-path
                               :payment-branch payment-path}
-                   :liveness
-                   {:payment-possible
-                    {:quantifier :existential
-                     :eventually #{:payment}}}})]
+                   :possible #{:payment}})]
 
       ;; Should return nil - no violation because payment-branch satisfies the property
       (is (nil? result)
-          "Should return nil when existential liveness property is satisfied on at least one path"))))
+          "Should return nil when possible check is satisfied on at least one path"))))
 
-(deftest existential-liveness-violation-no-path-satisfies
-  (testing "Existential liveness violation when NO path satisfies the predicate"
-    ;; This is Cycle 2.7: existential quantifier with NO satisfying paths
-    ;; Two branches:
-    ;; - One branch requests :failure-a then terminates (no :payment)
-    ;; - Other branch requests :failure-b then terminates (no :payment)
-    ;; The liveness property requires :payment to occur on AT LEAST ONE path
-    ;; Expected: liveness-violation because neither path has :payment
-
-    ;; Strategy: Two bthreads that both offer events at the first sync point
-    ;; This creates branching that the model checker will explore
+(deftest possible-check-violation-no-path-satisfies
+  (testing "Possible check violation violation when NO path satisfies the predicate"
     (let [failure-path-a
           (b/bids [{:request #{:failure-a}}
                    {:request #{{:type :done-a :terminal true}}}])
@@ -732,21 +714,10 @@
           result (check/check
                   {:bthreads {:failure-branch-a failure-path-a
                               :failure-branch-b failure-path-b}
-                   :liveness
-                   {:payment-possible
-                    {:quantifier :existential
-                     :eventually #{:payment}}}})]
+                   :possible #{:payment}})]
 
-      ;; Should return liveness-violation because NO path satisfies the property
-      ;; New format: check for :liveness-violations vector
-      (is (seq (:liveness-violations result))
-          "Should detect liveness violation when no path satisfies existential property")
-
-      (when-let [violation (first (:liveness-violations result))]
-        (is (= :payment-possible (:property violation))
-            "Should identify which property was violated")
-        (is (= :existential (:quantifier violation))
-            "Should report the existential quantifier")))))
+      (is (= #{:payment} (:impossible result))
+          "Should detect impossible event when no path contains the requested event"))))
 
 (deftest multiple-liveness-properties-reports-first-violation
   (testing "Multiple liveness properties checked, reporting first violation found"
@@ -838,9 +809,9 @@
                                               {:request #{:pong}}])}
                    :check-livelock? false ;; Disable structural livelock to isolate liveness
                    :liveness
-                    {:payment-required
-                     {:quantifier :universal
-                      :eventually #{:payment}}}})]
+                   {:payment-required
+                    {:quantifier :universal
+                     :eventually #{:payment}}}})]
 
       ;; This test SHOULD fail with current implementation
       ;; because cycles are not checked yet
@@ -862,85 +833,32 @@
           (is (= #{:ping :pong} (set (:cycle violation)))
               "Cycle should show the ping-pong events that loop forever without payment"))))))
 
-(deftest existential-liveness-checks-cycles-with-eventually
-  (testing "Existential liveness with :eventually should check cycles for satisfaction"
-    ;; A bthread that loops forever on :payment/:ack (infinite cycle)
-    ;; Liveness property requires :payment to occur on SOME path
-    ;; Expected: nil (NO violation) because the cycle DOES contain :payment, satisfying the existential property
-    ;; Current buggy behavior: Returns {:type :liveness-violation ...} (BUG — cycles not checked, only terminating paths)
-    ;;
-    ;; We disable structural livelock checking to isolate liveness behavior
+(deftest possible-checks-cycles-with-eventually
+  (testing "Possible checks with :eventually should check cycles for satisfaction"
     (let [result (check/check
                   {:bthreads {:payment-loop
                               (b/round-robin [{:request #{:payment}}
                                               {:request #{:ack}}])}
                    :check-livelock? false ;; Disable structural livelock to isolate liveness
-                   :liveness
-                    {:payment-possible
-                     {:quantifier :existential
-                      :eventually #{:payment}}}})]
-
-      ;; This test SHOULD fail with current implementation
-      ;; because cycles are not checked yet — only terminating paths
-      ;; The bug causes a false positive: it reports a violation when there shouldn't be one
-      (is (nil? result)
-          "Should return nil when existential liveness property is satisfied in cycle"))))
-
-(deftest legacy-liveness-predicate-is-rejected
-  (testing "Legacy trace-based liveness :predicate is rejected with guidance toward supported event-local forms"
-    (is (thrown-with-msg?
-         Throwable
-         #"(?is).*liveness.*:predicate.*(event-local|:eventually|supported).*"
-         (check/check
-          {:bthreads {:terminate-immediately
-                      (b/bids [{:request #{{:type :done :terminal true}}}])}
-           :liveness
-           {:payment-required
-            {:quantifier :universal
-             :predicate (fn [trace]
-                          (some #(= :payment (tech.thomascothran.pavlov.event/type %)) trace))}}}))
-        "Should reject legacy trace-based :predicate and direct callers to supported event-local forms")))
-
-(deftest existential-liveness-event-predicate-satisfied
-  (testing "Existential liveness succeeds when some reachable event satisfies :event-predicate"
-    (let [result
-          (check/check
-           {:bthreads {::failure-branch
-                       (b/bids [{:request #{{:type ::progress
-                                             :branch :failure}}}
-                                {:request #{{:type ::done-failure
-                                             :terminal true}}}])
-
-                       ::success-branch
-                       (b/bids [{:request #{{:type ::progress
-                                             :branch :success
-                                             :edge-token ::match}}}
-                                {:request #{{:type ::done-success
-                                             :terminal true}}}])}
-            :liveness {::progress-possible
-                       {:quantifier :existential
-                        :event-predicate (fn [event]
-                                           (= ::match (:edge-token event)))}}
-            :check-deadlock? false
-            :check-livelock? false})]
+                   :possible #{:payment}})]
 
       (is (nil? result)
-          "Should return nil when a reachable event object satisfies :event-predicate"))))
+          "Should return nil when possible check is satisfied in cycle"))))
 
 (deftest universal-liveness-event-predicate-satisfied-on-terminating-path
   (testing "Universal liveness succeeds when every terminating path contains an event whose event object satisfies :event-predicate"
     (let [result
           (check/check
            {:bthreads {::payment-then-terminate
-                        (b/bids [{:request #{{:type ::progress
-                                              :stage :queued}}}
-                                 {:request #{{:type ::progress
-                                              :stage :paid
-                                              :invoice-id ::match}}}
-                                 {:request #{{:type ::done
-                                              :terminal true}}}])}
-             :liveness {::payment-required
-                        {:quantifier :universal
+                       (b/bids [{:request #{{:type ::progress
+                                             :stage :queued}}}
+                                {:request #{{:type ::progress
+                                             :stage :paid
+                                             :invoice-id ::match}}}
+                                {:request #{{:type ::done
+                                             :terminal true}}}])}
+            :liveness {::payment-required
+                       {:quantifier :universal
                         :event-predicate (fn [event]
                                            (= ::match (:invoice-id event)))}}
             :check-deadlock? false
@@ -969,8 +887,8 @@
       (is (nil? result)
           "Should return nil when every maximal execution in the reachable cycle contains an event object satisfying :event-predicate"))))
 
-(deftest existential-liveness-satisfied-via-spawned-environment-bthread
-  (testing "Existential liveness should see terminal paths reached through spawned environment bthreads"
+(deftest possible-satisfied-via-spawned-environment-bthread
+  (testing "Possible event check should see terminal paths reached through spawned environment bthreads"
     ;; Regression: the state-space search currently misses the :c -> ::done path when
     ;; an environment bthread spawns the bthread that requests :c.
     (let [control-result
@@ -983,9 +901,7 @@
                                    (b/bids [{:request #{:a}}
                                             {:request #{:b}}
                                             {:request #{:c}}])}
-            :liveness {::done-eventually
-                       {:quantifier :existential
-                        :eventually #{::done}}}
+            :possible #{::done}
             :check-deadlock? false})
 
           bug-result
@@ -1000,31 +916,28 @@
                                             {:bthreads
                                              {::create
                                               (b/bids [{:request #{:c}}])}}])}
-            :liveness {::done-eventually
-                       {:quantifier :existential
-                        :eventually #{::done}}}
+            :possible #{::done}
             :check-deadlock? false})]
 
       (is (nil? control-result)
-          "Sanity check: direct environment path to ::done should satisfy existential liveness")
+          "Sanity check: direct environment path to ::done should satisfy the possibility check")
       (is (nil? bug-result)
-          "Spawned environment path to ::done should also satisfy existential liveness"))))
+          "Spawned environment path to ::done should also satisfy the possibility check"))))
 
-(deftest existential-liveness-preserves-satisfying-branch-after-convergence
-  (testing "Existential liveness should succeed when one branch satisfies the property before paths converge"
+(deftest possibility-check-preserves-satisfying-branch-after-convergence
+  (testing "Possibility check should succeed when one branch satisfies the property before paths converge"
     (let [result
           (check/check
            {:bthreads {::brancher (b/bids [{:request #{:a :b}}])
                        ::finisher (b/bids [{:wait-on #{:a :b}}
                                            {:request #{{:type ::done
                                                         :terminal true}}}])}
-            :liveness {::a-possible {:quantifier :existential
-                                     :eventually #{:a}}}
+            :possible #{:a}
             :check-deadlock? false
             :check-livelock? false})]
 
       (is (nil? result)
-          "A trace :a -> ::done exists, so existential liveness for :a should pass"))))
+          "A trace :a -> ::done exists, so possibility check for :a should pass"))))
 
 (deftest universal-liveness-detects-nonmatching-branch-after-convergence
   (testing "Universal liveness should fail when one reachable branch misses the matching event before convergence"
@@ -1297,9 +1210,9 @@
                   {:bthreads {:terminate-immediately
                               (b/bids [{:request #{{:type :done :terminal true}}}])}
                    :liveness
-                    {:payment-required
-                     {:quantifier :universal
-                      :eventually #{:payment}}}})]
+                   {:payment-required
+                    {:quantifier :universal
+                     :eventually #{:payment}}}})]
 
       (is (some? result)
           "Should detect liveness violation")

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
@@ -561,7 +561,7 @@
       (when result
         (is (true? (:truncated result))
             "Should mark the result as truncated")
-        (is (nil? (:liveness-violations result))
+        (is (nil? (:liveness-violation result))
             "Should suppress liveness violations when exploration is truncated")
         (is (nil? (:deadlocks result))
             "Should suppress deadlocks when exploration is truncated")))))
@@ -583,16 +583,16 @@
             "Should suppress impossible events when exploration is truncated")))))
 
 (deftest hot-deadlock-reports-liveness-and-deadlock
-  (testing "Hot deadlocks appear under :liveness-violations and :deadlocks"
+  (testing "Hot deadlocks appear under :liveness-violation and :deadlocks"
     (let [result (check/check {:bthreads (make-hot-deadlock-bthreads)})]
       (is (some? result)
           "Should detect the hot deadlock")
       (when result
-        (is (seq (:liveness-violations result))
+        (is (map? (:liveness-violation result))
             "Should report the hot deadlock as a liveness violation")
         (is (seq (:deadlocks result))
             "Should still report the structural deadlock")
-        (when-let [violation (first (:liveness-violations result))]
+        (when-let [violation (:liveness-violation result)]
           (is (some? (:node-id violation))
               "Should report the violating node")
           (is (= [:setup] (edge-types (:path-edges violation)))
@@ -606,17 +606,17 @@
           (is (not (contains? violation :trace))))))))
 
 (deftest hot-cycle-liveness-violation-reported-without-livelock-check
-  (testing "Hot cycles still report :liveness-violations when structural livelock checking is disabled"
+  (testing "Hot cycles still report :liveness-violation when structural livelock checking is disabled"
     (let [result (check/check {:bthreads (make-hot-cycle-bthreads)
                                :check-livelock? false})]
       (is (some? result)
           "Should detect the hot cycle")
       (when result
-        (is (seq (:liveness-violations result))
+        (is (map? (:liveness-violation result))
             "Should report the hot cycle as a liveness violation")
         (is (nil? (:livelocks result))
             "Should not report structural livelocks when disabled")
-        (when-let [violation (first (:liveness-violations result))]
+        (when-let [violation (:liveness-violation result)]
           (is (= [:setup] (edge-types (:path-edges violation)))
               "Path witness should stop at the hot cycle entry")
           (is (= [:ping :pong] (edge-types (:cycle-edges violation)))
@@ -630,7 +630,7 @@
       (is (some? result)
           "Should detect the hot cycle")
       (when result
-        (is (seq (:liveness-violations result))
+        (is (map? (:liveness-violation result))
             "Should report the hot cycle as a liveness violation")
         (is (seq (:livelocks result))
             "Should still report the structural livelock")))))
@@ -681,15 +681,16 @@
       (is (= #{:payment} (:impossible result))
           "Should detect impossible event when no path contains the requested event"))))
 
-(deftest top-level-liveness-config-is-rejected
-  (testing "Top-level :liveness config is rejected in favor of :hot and :possible"
-    (is (thrown-with-msg?
-         clojure.lang.ExceptionInfo
-         #":liveness"
-         (check/check {:bthreads (make-hot-terminal-bthreads)
-                       :liveness {:payment-required
-                                  {:quantifier :universal
-                                   :eventually #{:payment}}}})))))
+(deftest top-level-liveness-config-is-ignored
+  (testing "Top-level :liveness config does not affect hot-state liveness reporting"
+    (let [result (check/check {:bthreads (make-hot-terminal-bthreads)
+                               :liveness {:payment-required
+                                          {:quantifier :universal
+                                           :eventually #{:payment}}}})]
+      (is (some? result)
+          "Should still report the hot-state liveness witness")
+      (is (map? (:liveness-violation result))
+          "Should report the singular liveness witness key"))))
 
 (deftest possible-check-satisfied-in-cycle
   (testing "Possible checks should still succeed when the event appears in a reachable cycle"
@@ -907,14 +908,11 @@
         (is (nil? (:type result))
             "Result should NOT have top-level :type key in new format")
 
-        ;; New format: :liveness-violations is a vector
-        (is (vector? (:liveness-violations result))
-            "Result should have :liveness-violations as a vector")
+        ;; New format: :liveness-violation is a single map
+        (is (map? (:liveness-violation result))
+            "Result should have :liveness-violation as a map")
 
-        (is (= 1 (count (:liveness-violations result)))
-            "Should have exactly one liveness violation")
-
-        (let [violation (first (:liveness-violations result))]
+        (let [violation (:liveness-violation result)]
           ;; Individual violation does NOT have :type key
           (is (nil? (:type violation))
               "Individual liveness violation should NOT have :type key")

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
@@ -522,15 +522,13 @@
     ;; A bthread that terminates immediately without doing anything else
     ;; The liveness property requires :payment to occur on ALL paths
     ;; Expected: liveness violation because no :payment event occurred
-    (let [result (check/check
+     (let [result (check/check
                   {:bthreads {:terminate-immediately
                               (b/bids [{:request #{{:type :done :terminal true}}}])}
                    :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :predicate (fn [trace]
-                                  ;; Use pavlov.event/type to handle both keywords and maps
-                                  (some #(= :payment (tech.thomascothran.pavlov.event/type %)) trace))}}})]
+                    {:payment-required
+                     {:quantifier :universal
+                      :eventually #{:payment}}}})]
 
       ;; The test SHOULD fail because :liveness is not implemented yet
       ;; Either result will be nil (no violation detected) OR
@@ -559,16 +557,14 @@
     ;; A bthread that requests :payment first, then terminates
     ;; The liveness property requires :payment to occur on ALL paths
     ;; Expected: nil (no violation) because :payment occurred before termination
-    (let [result (check/check
+     (let [result (check/check
                   {:bthreads {:payment-then-terminate
                               (b/bids [{:request #{:payment}}
                                        {:request #{{:type :done :terminal true}}}])}
                    :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :predicate (fn [trace]
-                                  ;; Use pavlov.event/type to handle both keywords and maps
-                                  (some #(= :payment (tech.thomascothran.pavlov.event/type %)) trace))}}})]
+                    {:payment-required
+                     {:quantifier :universal
+                      :eventually #{:payment}}}})]
 
       ;; Should return nil - no violation
       (is (nil? result)
@@ -828,12 +824,12 @@
           (is (= #{:ping :pong} (set (:cycle livelock)))
               "Cycle should contain the ping-pong events that loop forever"))))))
 
-(deftest universal-liveness-predicate-checks-cycles
-  (testing "Universal liveness with PREDICATE (not :eventually) should check cycles for violations"
+(deftest universal-liveness-checks-cycles-with-eventually
+  (testing "Universal liveness with :eventually should check cycles for violations"
     ;; A bthread that loops forever on :ping/:pong (infinite cycle)
-    ;; Liveness property with CUSTOM PREDICATE (not :eventually shorthand) requires :payment
+    ;; Liveness property requires :payment
     ;; Expected: :liveness-violation because cycle doesn't contain :payment
-    ;; Current behavior: Returns nil (BUG — cycles not checked with :predicate)
+    ;; Current behavior: Returns nil (BUG — cycles not checked)
     ;;
     ;; We disable structural livelock checking to isolate liveness behavior
     (let [result (check/check
@@ -842,16 +838,14 @@
                                               {:request #{:pong}}])}
                    :check-livelock? false ;; Disable structural livelock to isolate liveness
                    :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     ;; Use CUSTOM PREDICATE (not :eventually) to expose the bug
-                     :predicate (fn [trace]
-                                  (some #(= :payment (tech.thomascothran.pavlov.event/type %)) trace))}}})]
+                    {:payment-required
+                     {:quantifier :universal
+                      :eventually #{:payment}}}})]
 
       ;; This test SHOULD fail with current implementation
-      ;; because cycles are not checked when using :predicate
+      ;; because cycles are not checked yet
       (is (some? result)
-          "Should detect liveness violation in cycle when using :predicate")
+          "Should detect liveness violation in cycle")
 
       (when result
         ;; New format: check for :liveness-violations vector (not :livelocks)
@@ -868,10 +862,10 @@
           (is (= #{:ping :pong} (set (:cycle violation)))
               "Cycle should show the ping-pong events that loop forever without payment"))))))
 
-(deftest existential-liveness-predicate-checks-cycles
-  (testing "Existential liveness with PREDICATE (not :eventually) should check cycles for satisfaction"
+(deftest existential-liveness-checks-cycles-with-eventually
+  (testing "Existential liveness with :eventually should check cycles for satisfaction"
     ;; A bthread that loops forever on :payment/:ack (infinite cycle)
-    ;; Liveness property with CUSTOM PREDICATE (not :eventually shorthand) requires :payment to occur on SOME path
+    ;; Liveness property requires :payment to occur on SOME path
     ;; Expected: nil (NO violation) because the cycle DOES contain :payment, satisfying the existential property
     ;; Current buggy behavior: Returns {:type :liveness-violation ...} (BUG — cycles not checked, only terminating paths)
     ;;
@@ -882,17 +876,98 @@
                                               {:request #{:ack}}])}
                    :check-livelock? false ;; Disable structural livelock to isolate liveness
                    :liveness
-                   {:payment-possible
-                    {:quantifier :existential
-                     ;; Use CUSTOM PREDICATE (not :eventually) to expose the bug
-                     :predicate (fn [trace]
-                                  (some #(= :payment (tech.thomascothran.pavlov.event/type %)) trace))}}})]
+                    {:payment-possible
+                     {:quantifier :existential
+                      :eventually #{:payment}}}})]
 
       ;; This test SHOULD fail with current implementation
-      ;; because cycles are not checked when using :predicate — only terminating paths
+      ;; because cycles are not checked yet — only terminating paths
       ;; The bug causes a false positive: it reports a violation when there shouldn't be one
       (is (nil? result)
-          "Should return nil when existential liveness property is satisfied in cycle using :predicate"))))
+          "Should return nil when existential liveness property is satisfied in cycle"))))
+
+(deftest legacy-liveness-predicate-is-rejected
+  (testing "Legacy trace-based liveness :predicate is rejected with guidance toward supported event-local forms"
+    (is (thrown-with-msg?
+         Throwable
+         #"(?is).*liveness.*:predicate.*(event-local|:eventually|supported).*"
+         (check/check
+          {:bthreads {:terminate-immediately
+                      (b/bids [{:request #{{:type :done :terminal true}}}])}
+           :liveness
+           {:payment-required
+            {:quantifier :universal
+             :predicate (fn [trace]
+                          (some #(= :payment (tech.thomascothran.pavlov.event/type %)) trace))}}}))
+        "Should reject legacy trace-based :predicate and direct callers to supported event-local forms")))
+
+(deftest existential-liveness-event-predicate-satisfied
+  (testing "Existential liveness succeeds when some reachable event satisfies :event-predicate"
+    (let [result
+          (check/check
+           {:bthreads {::failure-branch
+                       (b/bids [{:request #{{:type ::progress
+                                             :branch :failure}}}
+                                {:request #{{:type ::done-failure
+                                             :terminal true}}}])
+
+                       ::success-branch
+                       (b/bids [{:request #{{:type ::progress
+                                             :branch :success
+                                             :edge-token ::match}}}
+                                {:request #{{:type ::done-success
+                                             :terminal true}}}])}
+            :liveness {::progress-possible
+                       {:quantifier :existential
+                        :event-predicate (fn [event]
+                                           (= ::match (:edge-token event)))}}
+            :check-deadlock? false
+            :check-livelock? false})]
+
+      (is (nil? result)
+          "Should return nil when a reachable event object satisfies :event-predicate"))))
+
+(deftest universal-liveness-event-predicate-satisfied-on-terminating-path
+  (testing "Universal liveness succeeds when every terminating path contains an event whose event object satisfies :event-predicate"
+    (let [result
+          (check/check
+           {:bthreads {::payment-then-terminate
+                        (b/bids [{:request #{{:type ::progress
+                                              :stage :queued}}}
+                                 {:request #{{:type ::progress
+                                              :stage :paid
+                                              :invoice-id ::match}}}
+                                 {:request #{{:type ::done
+                                              :terminal true}}}])}
+             :liveness {::payment-required
+                        {:quantifier :universal
+                        :event-predicate (fn [event]
+                                           (= ::match (:invoice-id event)))}}
+            :check-deadlock? false
+            :check-livelock? false})]
+
+      (is (nil? result)
+          "Should return nil when each maximal terminating execution contains an event object satisfying :event-predicate"))))
+
+(deftest universal-liveness-event-predicate-satisfied-in-cycle
+  (testing "Universal liveness should inspect full cycle event objects for :event-predicate satisfaction"
+    (let [result
+          (check/check
+           {:bthreads {::payment-loop
+                       (b/round-robin [{:request #{{:type ::progress
+                                                    :stage :queued}}}
+                                       {:request #{{:type ::progress
+                                                    :stage :paid
+                                                    :invoice-id ::match}}}])}
+            :liveness {::payment-required
+                       {:quantifier :universal
+                        :event-predicate (fn [event]
+                                           (= ::match (:invoice-id event)))}}
+            :check-deadlock? false
+            :check-livelock? false})]
+
+      (is (nil? result)
+          "Should return nil when every maximal execution in the reachable cycle contains an event object satisfying :event-predicate"))))
 
 (deftest existential-liveness-satisfied-via-spawned-environment-bthread
   (testing "Existential liveness should see terminal paths reached through spawned environment bthreads"
@@ -934,6 +1009,83 @@
           "Sanity check: direct environment path to ::done should satisfy existential liveness")
       (is (nil? bug-result)
           "Spawned environment path to ::done should also satisfy existential liveness"))))
+
+(deftest existential-liveness-preserves-satisfying-branch-after-convergence
+  (testing "Existential liveness should succeed when one branch satisfies the property before paths converge"
+    (let [result
+          (check/check
+           {:bthreads {::brancher (b/bids [{:request #{:a :b}}])
+                       ::finisher (b/bids [{:wait-on #{:a :b}}
+                                           {:request #{{:type ::done
+                                                        :terminal true}}}])}
+            :liveness {::a-possible {:quantifier :existential
+                                     :eventually #{:a}}}
+            :check-deadlock? false
+            :check-livelock? false})]
+
+      (is (nil? result)
+          "A trace :a -> ::done exists, so existential liveness for :a should pass"))))
+
+(deftest universal-liveness-detects-nonmatching-branch-after-convergence
+  (testing "Universal liveness should fail when one reachable branch misses the matching event before convergence"
+    (let [result
+          (check/check
+           {:bthreads {::brancher (b/bids [{:request #{::paid ::skipped}}])
+                       ::finisher (b/bids [{:wait-on #{::paid ::skipped}}
+                                           {:request #{{:type ::done
+                                                        :terminal true}}}])}
+            :liveness {::payment-required {:quantifier :universal
+                                           :eventually #{::paid}}}
+            :check-deadlock? false
+            :check-livelock? false})]
+
+      (is (some? result)
+          "Should report a universal liveness violation because the ::skipped -> ::done execution never contains ::paid")
+
+      (when result
+        (is (seq (:liveness-violations result))
+            "Should report at least one liveness violation")
+
+        (when-let [violation (first (:liveness-violations result))]
+          (is (= ::payment-required (:property violation))
+              "Should identify the violated universal liveness property")
+          (is (= :universal (:quantifier violation))
+              "Should report the violated quantifier")
+          (is (= [::skipped ::done] (:trace violation))
+              "Should report the bad maximal execution that reaches the merged terminal state without ::paid"))))))
+
+(deftest universal-liveness-event-predicate-detects-nonmatching-branch-after-convergence
+  (testing "Universal liveness with :event-predicate should fail when one branch lacks a matching event object before convergence"
+    (let [result
+          (check/check
+           {:bthreads {::brancher
+                       (b/bids [{:request #{{:type ::progress
+                                             :invoice-id ::match}
+                                            {:type ::progress
+                                             :invoice-id ::other}}}])
+                       ::finisher
+                       (b/bids [{:wait-on #{::progress}}
+                                {:request #{{:type ::done
+                                             :terminal true}}}])}
+            :liveness {::payment-required
+                       {:quantifier :universal
+                        :event-predicate (fn [event]
+                                           (= ::match (:invoice-id event)))}}
+            :check-deadlock? false
+            :check-livelock? false})]
+
+      (is (some? result)
+          "Should report a universal liveness violation because one reachable ::progress branch never emits a matching event object before convergence")
+
+      (when result
+        (is (seq (:liveness-violations result))
+            "Should report at least one liveness violation")
+
+        (when-let [violation (first (:liveness-violations result))]
+          (is (= ::payment-required (:property violation))
+              "Should identify the violated universal liveness property")
+          (is (= :universal (:quantifier violation))
+              "Should report the violated quantifier"))))))
 
 (deftest universal-liveness-checks-deadlock-paths
   (testing "Universal liveness property should be checked on paths that end in deadlock"
@@ -1145,10 +1297,9 @@
                   {:bthreads {:terminate-immediately
                               (b/bids [{:request #{{:type :done :terminal true}}}])}
                    :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :predicate (fn [trace]
-                                  (some #(= :payment (tech.thomascothran.pavlov.event/type %)) trace))}}})]
+                    {:payment-required
+                     {:quantifier :universal
+                      :eventually #{:payment}}}})]
 
       (is (some? result)
           "Should detect liveness violation")

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
@@ -1,7 +1,8 @@
 (ns tech.thomascothran.pavlov.model.check-test
   (:require [clojure.test :refer [deftest testing is]]
             [tech.thomascothran.pavlov.model.check :as check]
-            [tech.thomascothran.pavlov.bthread :as b]))
+            [tech.thomascothran.pavlov.bthread :as b]
+            [tech.thomascothran.pavlov.event :as e]))
 
 (deftest good-morning-evening-model-check
   (testing "Model checker should verify good-morning/good-evening alternation"
@@ -172,6 +173,39 @@
     (b/on ::thing-fetched-from-cms
           (fn [_]
             {:request #{{:type ::update-thing}}}))]])
+
+(defn edge-types
+  [edges]
+  (mapv (comp e/type :event) edges))
+
+(defn make-hot-terminal-bthreads
+  []
+  {:finisher (b/bids [{:request #{{:type :done
+                                   :terminal true}}}])
+   :watcher (b/bids [{:wait-on #{:done}}
+                     {:hot true}])})
+
+(defn make-hot-deadlock-bthreads
+  []
+  {:starter (b/bids [{:request #{:setup}}])
+   :obligation (b/bids [{:wait-on #{:setup}}
+                        {:hot true}])})
+
+(defn make-hot-cycle-bthreads
+  []
+  (let [looper (b/step
+                (fn [state event]
+                  (case (or state :waiting)
+                    :waiting (if (= :setup event)
+                               [:ping {:request #{:ping}
+                                       :hot true}]
+                               [:waiting {:wait-on #{:setup}}])
+                    :ping [:pong {:request #{:pong}
+                                  :hot true}]
+                    :pong [:ping {:request #{:ping}
+                                  :hot true}])))]
+    {:starter (b/bids [{:request #{:setup}}])
+     :looper looper}))
 
 (deftest test-complex-identifier-bug
   ;; Catches another case where the state of a bthread does not change
@@ -453,22 +487,22 @@
     ;; The :loop-start branch leads to livelock (VIOLATION).
     (let [chooser
           (b/bids [{:request #{:loop-start
-                              {:type :terminate :terminal true}}}])
+                               {:type :terminate :terminal true}}}])
 
           looping-branch
           (b/step
-            (fn [state event]
-              (case (or state :waiting)
-                :waiting (if (= :loop-start event)
-                           [:ping {:request #{:ping}}]
-                           [:waiting {:wait-on #{:loop-start}}])
-                :ping [:pong {:request #{:pong}}]
-                :pong [:ping {:request #{:ping}}])))
+           (fn [state event]
+             (case (or state :waiting)
+               :waiting (if (= :loop-start event)
+                          [:ping {:request #{:ping}}]
+                          [:waiting {:wait-on #{:loop-start}}])
+               :ping [:pong {:request #{:pong}}]
+               :pong [:ping {:request #{:ping}}])))
 
           result (check/check
                   {:bthreads {:chooser chooser
-                               :looping looping-branch}
-                    :check-livelock? true})]
+                              :looping looping-branch}
+                   :check-livelock? true})]
       (is (some? result)
           "Should detect a livelock even though one branch terminates")
       (when result
@@ -511,19 +545,16 @@
         (is (true? (:truncated result))
             "Should have :truncated true when max-nodes exceeded")))))
 
-(deftest truncation-suppresses-liveness-violations
-  (testing "Should not report liveness violations from a truncated graph"
-    (let [worker (b/step
-                  (fn [state _event]
-                    (let [n (or state 0)]
-                      (if (< n 5)
-                        [(inc n) {:request #{(keyword (str "event-" n))}}]
-                        [(inc n) {:request #{:payment}}]))))
-          result (check/check
-                  {:bthreads {:worker worker}
-                   :liveness {:payment-required
-                              {:quantifier :universal
-                               :eventually #{:payment}}}
+(deftest truncation-suppresses-hot-liveness-violations
+  (testing "Should not report hot-state liveness violations from a truncated graph"
+    (let [result (check/check
+                  {:bthreads
+                   {:worker (b/bids [{:request #{:event-0}}
+                                     {:request #{:event-1}}
+                                     {:request #{:event-2}}
+                                     {:request #{:event-3}}
+                                     {:request #{:event-4}}
+                                     {:hot true}])}
                    :max-nodes 2})]
       (is (some? result)
           "Should still return a truncation result")
@@ -535,168 +566,74 @@
         (is (nil? (:deadlocks result))
             "Should suppress deadlocks when exploration is truncated")))))
 
-(deftest universal-liveness-violation-on-terminating-path
-  (testing "Universal liveness property violated when path terminates without satisfying predicate"
-    ;; This is Cycle 2.1: simplest liveness check
-    ;; A bthread that terminates immediately without doing anything else
-    ;; The liveness property requires :payment to occur on ALL paths
-    ;; Expected: liveness violation because no :payment event occurred
+(deftest truncation-suppresses-impossible-events
+  (testing "Should not report impossible events from a truncated graph"
     (let [result (check/check
-                  {:bthreads {:terminate-immediately
-                              (b/bids [{:request #{{:type :done :terminal true}}}])}
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; The test SHOULD fail because :liveness is not implemented yet
-      ;; Either result will be nil (no violation detected) OR
-      ;; an error will be thrown about unknown option
+                  {:bthreads {:worker (b/bids [{:request #{:a}}
+                                               {:request #{:b}}
+                                               {:request #{:payment}}])}
+                   :possible #{:payment}
+                   :max-nodes 2})]
       (is (some? result)
-          "Should detect liveness violation")
-
+          "Should still return a truncation result")
       (when result
-        ;; New format: check for :liveness-violations vector
+        (is (true? (:truncated result))
+            "Should mark the result as truncated")
+        (is (nil? (:impossible result))
+            "Should suppress impossible events when exploration is truncated")))))
+
+(deftest hot-deadlock-reports-liveness-and-deadlock
+  (testing "Hot deadlocks appear under :liveness-violations and :deadlocks"
+    (let [result (check/check {:bthreads (make-hot-deadlock-bthreads)})]
+      (is (some? result)
+          "Should detect the hot deadlock")
+      (when result
         (is (seq (:liveness-violations result))
-            "Should have liveness violations in new format")
-
+            "Should report the hot deadlock as a liveness violation")
+        (is (seq (:deadlocks result))
+            "Should still report the structural deadlock")
         (when-let [violation (first (:liveness-violations result))]
-          (is (= :payment-required (:property violation))
-              "Should identify which property was violated")
-          (is (= :universal (:quantifier violation))
-              "Should report the quantifier used")
-          (is (vector? (:trace violation))
-              "Should include the trace that violated the property")
-          (is (= [:done] (:trace violation))
-              "Trace should show the path that terminated without payment"))))))
+          (is (some? (:node-id violation))
+              "Should report the violating node")
+          (is (= [:setup] (edge-types (:path-edges violation)))
+              "Path witness should include the edge into the hot deadlock")
+          (is (not (contains? violation :cycle-edges))
+              "Deadlock witness should not include a cycle")
+          (is (:hot (:state violation))
+              "Violation should report the hot node state")
+          (is (not (contains? violation :property)))
+          (is (not (contains? violation :quantifier)))
+          (is (not (contains? violation :trace))))))))
 
-(deftest universal-liveness-satisfied-on-terminating-path
-  (testing "Universal liveness property satisfied when payment occurs before termination"
-    ;; This is Cycle 2.2: liveness property is satisfied
-    ;; A bthread that requests :payment first, then terminates
-    ;; The liveness property requires :payment to occur on ALL paths
-    ;; Expected: nil (no violation) because :payment occurred before termination
-    (let [result (check/check
-                  {:bthreads {:payment-then-terminate
-                              (b/bids [{:request #{:payment}}
-                                       {:request #{{:type :done :terminal true}}}])}
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; Should return nil - no violation
-      (is (nil? result)
-          "Should return nil when liveness property is satisfied"))))
-
-(deftest universal-liveness-eventually-shorthand
-  (testing "Universal liveness using :eventually shorthand for common case"
-    ;; This is Cycle 2.3: syntactic sugar for event type checking
-    ;; Same as Cycle 2.1, but using :eventually #{:payment} instead of :predicate
-    ;; A bthread that terminates immediately without doing anything else
-    ;; The liveness property requires :payment to occur on ALL paths using the shorthand
-    ;; Expected: same liveness violation as Cycle 2.1
-    (let [result (check/check
-                  {:bthreads {:terminate-immediately
-                              (b/bids [{:request #{{:type :done :terminal true}}}])}
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; The test SHOULD fail because :eventually is not implemented yet
-      ;; Either result will be nil (no violation detected) OR
-      ;; an error will be thrown about unknown option
+(deftest hot-cycle-liveness-violation-reported-without-livelock-check
+  (testing "Hot cycles still report :liveness-violations when structural livelock checking is disabled"
+    (let [result (check/check {:bthreads (make-hot-cycle-bthreads)
+                               :check-livelock? false})]
       (is (some? result)
-          "Should detect liveness violation")
-
+          "Should detect the hot cycle")
       (when result
-        ;; New format: check for :liveness-violations vector
         (is (seq (:liveness-violations result))
-            "Should have liveness violations in new format")
-
+            "Should report the hot cycle as a liveness violation")
+        (is (nil? (:livelocks result))
+            "Should not report structural livelocks when disabled")
         (when-let [violation (first (:liveness-violations result))]
-          (is (= :payment-required (:property violation))
-              "Should identify which property was violated")
-          (is (= :universal (:quantifier violation))
-              "Should report the quantifier used")
-          (is (vector? (:trace violation))
-              "Should include the trace that violated the property")
-          (is (= [:done] (:trace violation))
-              "Trace should show the path that terminated without payment"))))))
+          (is (= [:setup] (edge-types (:path-edges violation)))
+              "Path witness should stop at the hot cycle entry")
+          (is (= [:ping :pong] (edge-types (:cycle-edges violation)))
+              "Cycle witness should contain the hot cycle edges")
+          (is (:hot (:state violation))
+              "Violation should report the hot entry state"))))))
 
-(deftest universal-liveness-violation-in-cycle
-  (testing "Universal liveness property violated when trapped in cycle without satisfying event"
-    ;; This is Cycle 2.4: liveness violation in a cycle
-    ;; A bthread that loops forever on :ping/:pong
-    ;; The liveness property requires :payment to occur on ALL paths
-    ;; Expected: liveness violation because the cycle never contains :payment
-    ;; Note: We disable structural livelock checking to isolate liveness behavior
-    (let [result (check/check
-                  {:bthreads {:ping-pong
-                              (b/round-robin [{:request #{:ping}}
-                                              {:request #{:pong}}])}
-                   :check-livelock? false ;; Disable structural livelock to isolate liveness
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; The test SHOULD fail because liveness checking in cycles is not implemented yet
+(deftest hot-cycle-still-reports-livelock
+  (testing "Hot cycles overlap with structural :livelocks"
+    (let [result (check/check {:bthreads (make-hot-cycle-bthreads)})]
       (is (some? result)
-          "Should detect liveness violation in cycle")
-
+          "Should detect the hot cycle")
       (when result
-        ;; New format: check for :liveness-violations vector
         (is (seq (:liveness-violations result))
-            "Should have liveness violations in new format (not :livelocks)")
-
-        (when-let [violation (first (:liveness-violations result))]
-          (is (= :payment-required (:property violation))
-              "Should identify which property was violated")
-          (is (= :universal (:quantifier violation))
-              "Should report the quantifier used")
-          (is (vector? (:cycle violation))
-              "Should include the cycle that violated the property")
-          (is (= #{:ping :pong} (set (:cycle violation)))
-              "Cycle should show the ping-pong events that loop forever without payment"))))))
-
-(deftest universal-liveness-satisfied-in-cycle-still-reports-livelock
-  (testing "Universal liveness satisfied in cycle, but structural livelock still reported"
-    ;; This is Cycle 2.5: liveness property IS satisfied within the cycle
-    ;; A bthread that loops forever on :payment/:ack/:payment...
-    ;; The liveness property requires :payment to occur on ALL paths
-    ;; Expected: structural livelock is reported because the program loops forever
-    ;;           BUT NOT a liveness violation because :payment does occur in the cycle
-    ;; Design decision: structural livelocks are always reported regardless of liveness properties
-    (let [result (check/check
-                  {:bthreads {:payment-loop
-                              (b/round-robin [{:request #{:payment}}
-                                              {:request #{:ack}}])}
-                   :check-livelock? true ;; Enable structural livelock checking (default)
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; Should detect structural livelock
-      (is (some? result)
-          "Should detect a structural livelock even though liveness is satisfied")
-
-      (when result
-        ;; New format: check for :livelocks vector (NOT :liveness-violations)
+            "Should report the hot cycle as a liveness violation")
         (is (seq (:livelocks result))
-            "Should have livelocks in new format (NOT :liveness-violations)")
-
-        (when-let [livelock (first (:livelocks result))]
-          (is (vector? (:cycle livelock))
-              "Should include the cycle")
-          ;; Verify that the cycle contains :payment, which satisfies the liveness property
-          (is (some #(= :payment %) (:cycle livelock))
-              "Cycle should contain :payment event, satisfying the liveness property")
-          ;; Verify the cycle is what we expect
-          (is (= #{:payment :ack} (set (:cycle livelock)))
-              "Cycle should contain :payment and :ack events"))))))
+            "Should still report the structural livelock")))))
 
 (deftest possible-check-satisfied-one-path
   (testing "Possible check is satisfied when ANY path contains the event"
@@ -744,122 +681,18 @@
       (is (= #{:payment} (:impossible result))
           "Should detect impossible event when no path contains the requested event"))))
 
-(deftest multiple-liveness-properties-reports-first-violation
-  (testing "Multiple liveness properties checked, reporting first violation found"
-    ;; This is Cycle 2.8: multiple liveness properties
-    ;; A bthread that requests :payment then terminates (no :shipment)
-    ;; Two liveness properties:
-    ;; - :payment-ok requires :payment on ALL paths — SATISFIED
-    ;; - :shipment-ok requires :shipment on ALL paths — VIOLATED
-    ;; Expected: violation for :shipment-ok (not :payment-ok)
-    (let [result (check/check
-                  {:bthreads {:payment-then-terminate
-                              (b/bids [{:request #{:payment}}
-                                       {:request #{{:type :done :terminal true}}}])}
-                   :liveness
-                   {:payment-ok
-                    {:quantifier :universal
-                     :eventually #{:payment}}
-                    :shipment-ok
-                    {:quantifier :universal
-                     :eventually #{:shipment}}}})]
+(deftest top-level-liveness-config-is-rejected
+  (testing "Top-level :liveness config is rejected in favor of :hot and :possible"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #":liveness"
+         (check/check {:bthreads (make-hot-terminal-bthreads)
+                       :liveness {:payment-required
+                                  {:quantifier :universal
+                                   :eventually #{:payment}}}})))))
 
-      ;; Should detect liveness violation for :shipment-ok
-      (is (some? result)
-          "Should detect liveness violation")
-
-      (when result
-        ;; New format: check for :liveness-violations vector
-        (is (seq (:liveness-violations result))
-            "Should have liveness violations in new format")
-
-        (when-let [violation (first (:liveness-violations result))]
-          (is (= :shipment-ok (:property violation))
-              "Should identify :shipment-ok as the violated property (not :payment-ok)")
-          (is (= :universal (:quantifier violation))
-              "Should report the quantifier used")
-          (is (vector? (:trace violation))
-              "Should include the trace that violated the property")
-          ;; The trace should show :payment then :done
-          ;; :payment satisfies :payment-ok, but :shipment is never requested
-          (is (= #{:payment :done} (set (:trace violation)))
-              "Trace should contain :payment and :done events"))))))
-
-(deftest priority-livelock-before-liveness-violation
-  (testing "Structural livelock is reported before liveness violation"
-    ;; This is Cycle 2.9: priority order when both violations exist
-    ;; A bthread that loops forever on :ping/:pong (structural livelock)
-    ;; Liveness property requires :payment to occur on ALL paths
-    ;; Expected: :livelock violation (NOT :liveness-violation)
-    ;; Rationale: Structural livelock is more severe (pegs CPU at 100%)
-    ;;            User should know about the infinite loop first
-    (let [result (check/check
-                  {:bthreads {:ping-pong
-                              (b/round-robin [{:request #{:ping}}
-                                              {:request #{:pong}}])}
-                   :check-livelock? true ;; Enable structural livelock checking (default)
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; Should detect structural livelock (not liveness violation)
-      (is (some? result)
-          "Should detect a violation")
-
-      (when result
-        ;; New format: both :livelocks and :liveness-violations may be present
-        ;; but :livelocks should be present (structural livelock has priority in old format,
-        ;; in new format both are returned but livelocks should be there)
-        (is (seq (:livelocks result))
-            "Should have livelocks in new format (structural livelock has priority)")
-
-        (when-let [livelock (first (:livelocks result))]
-          (is (vector? (:cycle livelock))
-              "Should include the cycle")
-          (is (= #{:ping :pong} (set (:cycle livelock)))
-              "Cycle should contain the ping-pong events that loop forever"))))))
-
-(deftest universal-liveness-checks-cycles-with-eventually
-  (testing "Universal liveness with :eventually should check cycles for violations"
-    ;; A bthread that loops forever on :ping/:pong (infinite cycle)
-    ;; Liveness property requires :payment
-    ;; Expected: :liveness-violation because cycle doesn't contain :payment
-    ;; Current behavior: Returns nil (BUG — cycles not checked)
-    ;;
-    ;; We disable structural livelock checking to isolate liveness behavior
-    (let [result (check/check
-                  {:bthreads {:ping-pong
-                              (b/round-robin [{:request #{:ping}}
-                                              {:request #{:pong}}])}
-                   :check-livelock? false ;; Disable structural livelock to isolate liveness
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; This test SHOULD fail with current implementation
-      ;; because cycles are not checked yet
-      (is (some? result)
-          "Should detect liveness violation in cycle")
-
-      (when result
-        ;; New format: check for :liveness-violations vector (not :livelocks)
-        (is (seq (:liveness-violations result))
-            "Should have liveness violations in new format (not :livelocks)")
-
-        (when-let [violation (first (:liveness-violations result))]
-          (is (= :payment-required (:property violation))
-              "Should identify which property was violated")
-          (is (= :universal (:quantifier violation))
-              "Should report the quantifier used")
-          (is (vector? (:cycle violation))
-              "Should include the cycle that violated the property")
-          (is (= #{:ping :pong} (set (:cycle violation)))
-              "Cycle should show the ping-pong events that loop forever without payment"))))))
-
-(deftest possible-checks-cycles-with-eventually
-  (testing "Possible checks with :eventually should check cycles for satisfaction"
+(deftest possible-check-satisfied-in-cycle
+  (testing "Possible checks should still succeed when the event appears in a reachable cycle"
     (let [result (check/check
                   {:bthreads {:payment-loop
                               (b/round-robin [{:request #{:payment}}
@@ -869,48 +702,6 @@
 
       (is (nil? result)
           "Should return nil when possible check is satisfied in cycle"))))
-
-(deftest universal-liveness-event-predicate-satisfied-on-terminating-path
-  (testing "Universal liveness succeeds when every terminating path contains an event whose event object satisfies :event-predicate"
-    (let [result
-          (check/check
-           {:bthreads {::payment-then-terminate
-                       (b/bids [{:request #{{:type ::progress
-                                             :stage :queued}}}
-                                {:request #{{:type ::progress
-                                             :stage :paid
-                                             :invoice-id ::match}}}
-                                {:request #{{:type ::done
-                                             :terminal true}}}])}
-            :liveness {::payment-required
-                       {:quantifier :universal
-                        :event-predicate (fn [event]
-                                           (= ::match (:invoice-id event)))}}
-            :check-deadlock? false
-            :check-livelock? false})]
-
-      (is (nil? result)
-          "Should return nil when each maximal terminating execution contains an event object satisfying :event-predicate"))))
-
-(deftest universal-liveness-event-predicate-satisfied-in-cycle
-  (testing "Universal liveness should inspect full cycle event objects for :event-predicate satisfaction"
-    (let [result
-          (check/check
-           {:bthreads {::payment-loop
-                       (b/round-robin [{:request #{{:type ::progress
-                                                    :stage :queued}}}
-                                       {:request #{{:type ::progress
-                                                    :stage :paid
-                                                    :invoice-id ::match}}}])}
-            :liveness {::payment-required
-                       {:quantifier :universal
-                        :event-predicate (fn [event]
-                                           (= ::match (:invoice-id event)))}}
-            :check-deadlock? false
-            :check-livelock? false})]
-
-      (is (nil? result)
-          "Should return nil when every maximal execution in the reachable cycle contains an event object satisfying :event-predicate"))))
 
 (deftest possible-satisfied-via-spawned-environment-bthread
   (testing "Possible event check should see terminal paths reached through spawned environment bthreads"
@@ -963,131 +754,6 @@
 
       (is (nil? result)
           "A trace :a -> ::done exists, so possibility check for :a should pass"))))
-
-(deftest universal-liveness-detects-nonmatching-branch-after-convergence
-  (testing "Universal liveness should fail when one reachable branch misses the matching event before convergence"
-    (let [result
-          (check/check
-           {:bthreads {::brancher (b/bids [{:request #{::paid ::skipped}}])
-                       ::finisher (b/bids [{:wait-on #{::paid ::skipped}}
-                                           {:request #{{:type ::done
-                                                        :terminal true}}}])}
-            :liveness {::payment-required {:quantifier :universal
-                                           :eventually #{::paid}}}
-            :check-deadlock? false
-            :check-livelock? false})]
-
-      (is (some? result)
-          "Should report a universal liveness violation because the ::skipped -> ::done execution never contains ::paid")
-
-      (when result
-        (is (seq (:liveness-violations result))
-            "Should report at least one liveness violation")
-
-        (when-let [violation (first (:liveness-violations result))]
-          (is (= ::payment-required (:property violation))
-              "Should identify the violated universal liveness property")
-          (is (= :universal (:quantifier violation))
-              "Should report the violated quantifier")
-          (is (= [::skipped ::done] (:trace violation))
-              "Should report the bad maximal execution that reaches the merged terminal state without ::paid"))))))
-
-(deftest universal-liveness-event-predicate-detects-nonmatching-branch-after-convergence
-  (testing "Universal liveness with :event-predicate should fail when one branch lacks a matching event object before convergence"
-    (let [result
-          (check/check
-           {:bthreads {::brancher
-                       (b/bids [{:request #{{:type ::progress
-                                             :invoice-id ::match}
-                                            {:type ::progress
-                                             :invoice-id ::other}}}])
-                       ::finisher
-                       (b/bids [{:wait-on #{::progress}}
-                                {:request #{{:type ::done
-                                             :terminal true}}}])}
-            :liveness {::payment-required
-                       {:quantifier :universal
-                        :event-predicate (fn [event]
-                                           (= ::match (:invoice-id event)))}}
-            :check-deadlock? false
-            :check-livelock? false})]
-
-      (is (some? result)
-          "Should report a universal liveness violation because one reachable ::progress branch never emits a matching event object before convergence")
-
-      (when result
-        (is (seq (:liveness-violations result))
-            "Should report at least one liveness violation")
-
-        (when-let [violation (first (:liveness-violations result))]
-          (is (= ::payment-required (:property violation))
-              "Should identify the violated universal liveness property")
-          (is (= :universal (:quantifier violation))
-              "Should report the violated quantifier"))))))
-
-(deftest universal-liveness-checks-deadlock-paths
-  (testing "Universal liveness property should be checked on paths that end in deadlock"
-    ;; This is Cycle 3.3: Liveness on Deadlock Path
-    ;; A bthread that requests :process then deadlocks (no terminal event, no more bids)
-    ;; Liveness property requires :payment to occur on ALL paths
-    ;; Expected: :liveness-violation because the deadlock path doesn't have :payment
-    ;; Current behavior: Returns {:type :deadlock ...} (liveness not checked on deadlock paths)
-    ;;
-    ;; Key insight: Since liveness has higher priority than deadlock in our priority order,
-    ;; if we properly check liveness on deadlock paths, we should get a liveness violation,
-    ;; NOT a deadlock.
-    (let [result (check/check
-                  {:bthreads {:process-then-deadlock
-                              ;; Request :process then deadlock (no more bids, no terminal event)
-                              (b/bids [{:request #{:process}}])}
-                   :check-deadlock? true ;; Enable deadlock checking
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
-
-      ;; This test SHOULD fail with current implementation
-      ;; Expected: {:type :liveness-violation ...}
-      ;; Actual: {:type :deadlock ...}
-      (is (some? result)
-          "Should detect a violation (either liveness or deadlock)")
-
-      (when result
-        ;; New format: both violations may be present
-        ;; In the new format, we return ALL violations, so we might have both
-        ;; :liveness-violations and :deadlocks
-        ;; But we should at least have :liveness-violations
-        (is (seq (:liveness-violations result))
-            "Should have liveness violations in new format (liveness has higher priority)")
-
-        (when-let [violation (first (:liveness-violations result))]
-          (is (= :payment-required (:property violation))
-              "Should identify which property was violated")
-          (is (= :universal (:quantifier violation))
-              "Should report the quantifier used")
-          (is (vector? (:trace violation))
-              "Should include the trace that violated the property")
-          (is (= [:process] (:trace violation))
-              "Trace should show the :process event before deadlock, without :payment"))))))
-
-(deftest invalid-quantifier-throws-error
-  (testing "Invalid quantifier (typo) throws clear error"
-    ;; User provides :univrsal (missing 'e') instead of :universal
-    ;; Current: Throws IllegalArgumentException: No matching clause: :univrsal
-    ;; Expected: Either a clear error message OR graceful handling
-    ;;
-    ;; For now, we document and test the current behavior (throwing an exception)
-    ;; We can improve the error message later if needed
-    (is (thrown-with-msg?
-         IllegalArgumentException
-         #"No matching clause"
-         (check/check
-          {:bthreads {:simple (b/bids [{:request #{{:type :done :terminal true}}}])}
-           :liveness
-           {:payment-required
-            {:quantifier :univrsal ;; TYPO - should be :universal
-             :eventually #{:payment}}}}))
-        "Should throw IllegalArgumentException for invalid quantifier")))
 
 (deftest empty-bthreads-returns-nil
   (testing "Empty bthreads returns deadlock (empty program has no events and cannot terminate)"
@@ -1230,14 +896,8 @@
               "Safety violation should have :state"))))))
 
 (deftest new-format-single-liveness-violation
-  (testing "Single liveness violation returns in new format {:liveness-violations [...]}"
-    (let [result (check/check
-                  {:bthreads {:terminate-immediately
-                              (b/bids [{:request #{{:type :done :terminal true}}}])}
-                   :liveness
-                   {:payment-required
-                    {:quantifier :universal
-                     :eventually #{:payment}}}})]
+  (testing "Single hot-state liveness violation returns the direct witness shape"
+    (let [result (check/check {:bthreads (make-hot-terminal-bthreads)})]
 
       (is (some? result)
           "Should detect liveness violation")
@@ -1259,17 +919,24 @@
           (is (nil? (:type violation))
               "Individual liveness violation should NOT have :type key")
 
-          (is (= :payment-required (:property violation))
-              "Liveness violation should have :property")
+          (is (some? (:node-id violation))
+              "Liveness violation should have :node-id")
 
-          (is (= :universal (:quantifier violation))
-              "Liveness violation should have :quantifier")
+          (is (= [:done] (edge-types (:path-edges violation)))
+              "Path edges should witness the hot terminal event")
 
-          (is (vector? (:trace violation))
-              "Liveness violation should have :trace")
+          (is (not (contains? violation :cycle-edges))
+              "Hot terminal violation should not include a cycle witness")
 
-          (is (= [:done] (:trace violation))
-              "Trace should show termination without payment"))))))
+          (is (map? (:state violation))
+              "Liveness violation should have :state")
+
+          (is (:hot (:state violation))
+              "Violating state should be hot")
+
+          (is (not (contains? violation :property)))
+          (is (not (contains? violation :quantifier)))
+          (is (not (contains? violation :trace))))))))
 
 (deftest new-format-no-violations
   (testing "No violations returns nil"

--- a/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
+++ b/modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj
@@ -681,16 +681,22 @@
       (is (= #{:payment} (:impossible result))
           "Should detect impossible event when no path contains the requested event"))))
 
-(deftest top-level-liveness-config-is-ignored
-  (testing "Top-level :liveness config does not affect hot-state liveness reporting"
-    (let [result (check/check {:bthreads (make-hot-terminal-bthreads)
-                               :liveness {:payment-required
-                                          {:quantifier :universal
-                                           :eventually #{:payment}}}})]
+(deftest possible-and-hot-liveness-report-separately
+  (testing "Reachability checks via :possible stay separate from hot-state liveness"
+    (let [result (check/check
+                  {:bthreads {:order (b/bids [{:request #{:start-order}}])
+                              :await-payment (b/bids [{:wait-on #{:start-order}}
+                                                      {:wait-on #{:payment}
+                                                       :hot true}])}
+                   :possible #{:payment}})]
       (is (some? result)
-          "Should still report the hot-state liveness witness")
+          "Should report violations when payment is unreachable and the model stays hot")
+      (is (= #{:payment} (:impossible result))
+          "Should report the unreachable scenario via :impossible")
       (is (map? (:liveness-violation result))
-          "Should report the singular liveness witness key"))))
+          "Should report the hot-state witness separately under :liveness-violation")
+      (is (seq (:deadlocks result))
+          "Should still report the structural deadlock"))))
 
 (deftest possible-check-satisfied-in-cycle
   (testing "Possible checks should still succeed when the event appears in a reachable cycle"

--- a/modules/pavlov-skills/build.clj
+++ b/modules/pavlov-skills/build.clj
@@ -5,7 +5,7 @@
 
 (def lib 'tech.thomascothran/pavlov-skills)
 ;; alternatively, use MAJOR.MINOR.COMMITS:
-(def version (format "3.0.%s" (b/git-count-revs nil)))
+(def version (format "4.0.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 (def doc-dir (str class-dir "/tech/thomascothran/pavlov-skills/doc"))
 (def skills-dir (str class-dir "/skills"))

--- a/modules/pavlov-skills/skills/pavlov-domain-modeling/SKILL.md
+++ b/modules/pavlov-skills/skills/pavlov-domain-modeling/SKILL.md
@@ -9,7 +9,7 @@ Use this skill to guide a domain expert through a structured modeling session an
 
 ## Workflow (iterative).
 
-1. Facilitate a domain interview to capture the event catalog, initiating events, positive scenarios, safety properties, and universal properties.
+1. Facilitate a domain interview to capture the event catalog, initiating events, positive scenarios, safety properties, and progress obligations.
 2. Clarify which events are environment inputs vs domain-driven outcomes, including payload shapes and terminal/completion events.
 3. Draft bthreads, review with the domain expert, and iterate on the model until the scenarios and properties feel right.
 4. Generate the Clojure deliverables and update them as the domain knowledge evolves.
@@ -20,13 +20,13 @@ Use this skill to guide a domain expert through a structured modeling session an
 The deliverables are source code, by default:
 
 - `rules.clj`: domain rules bthreads; define `make-bthreads` returning a map of bthread name -> bthread.
-  + Universal liveness properties will be defined here as well.
+  + Put any hot-state progress obligations directly on bids with `:hot true`.
 - `environment.clj`: simulated environment inputs; define `make-bthreads` returning a map;
   + RULE: keep all *initiating events* (typically bthreads that make a `:request` in their first bid instead of a `:wait-on`) in *one* bthread that returns *one* bid where the requests are a set. Call this bthread `::init-events` (namespaced).
 - `safety.clj`: safety bthreads
-- `scenarios.clj`: positive scenarios; define `make-bthreads` returning a map; each scenario ends with a unique completion event. Define existential liveness properties for *each* completion event
-- `check.clj`: model-check setup; assemble `:bthreads`, `:safety-bthreads`, and `:liveness` (keep `:bthreads` as a map when start events come from environment bthreads).
-  + `:liveness` will need to include all the liveness definitions from the rules and scenarios
+- `scenarios.clj`: positive scenarios; define `make-bthreads` returning a map; each scenario ends with a unique completion event so `check.clj` can assert it with `:possible`
+- `check.clj`: model-check setup; assemble `:bthreads`, `:safety-bthreads`, and optionally `:possible` (keep `:bthreads` as a map when start events come from environment bthreads).
+  + `:possible` should include the scenario completion events you want to prove reachable
 - `viz.clj`: visualization helpers; define functions for nav exploration, Portal click-through, and graph export.
 
 The user may specify a directory or suggest alternative names.
@@ -47,9 +47,9 @@ DO NOT JUST READ CODE AND SAY WHAT YOU *THINK* IT DOES, EXECUTE AND **VERIFY** I
 
 - Keep environment inputs isolated in `environment.clj`; avoid mixing them with domain rules.
 - Keep scenarios linear (`b/bids` with `:wait-on`) and let branching happen in the init/environment layers.
-- Use namespaced completion events for scenarios so existential liveness properties stay explicit.
-- Put invariants in `:safety-bthreads` and progress requirements in `:liveness`.
-- Use one `check/check` call for the whole model. Define existential liveness checks for each scenario.
+- Use namespaced completion events for scenarios so `:possible` checks stay explicit.
+- Put invariants in `:safety-bthreads` and progress requirements on bids with `:hot true`.
+- Use one `check/check` call for the whole model. Define `:possible` checks for each scenario you want to prove reachable.
 
 ## References
 

--- a/modules/pavlov-skills/skills/pavlov-domain-modeling/references/bank-domain-example.md
+++ b/modules/pavlov-skills/skills/pavlov-domain-modeling/references/bank-domain-example.md
@@ -182,21 +182,61 @@ The `:invariant-violated` property tells our model checker that this specific ev
 
 If the `:ofac-clear` event occurs, then this bthread will no longer request the account-opened event with an invariant violation. Another bthread may request the `account-opened` event, but (so long as that event does not have `:invariant-violated` set to true) the model checker will accept it as valid.
 
+### Scenario and progress bthreads
+
+Safety is only part of the story. We usually also want to prove two positive properties:
+
+- some desired outcome is reachable on at least one path
+- once the application is in flight, it eventually resolves
+
+We model those with a scenario bthread plus a hot-state progress obligation:
+
+```clojure
+(ns bank.scenarios
+  (:require [tech.thomascothran.pavlov.bthread :as b]))
+
+(defn make-account-opened-scenario
+  []
+  (b/bids [{:wait-on #{:account-opened}}
+           {:request #{{:type :scenario/account-opened
+                        :terminal true}}}]))
+
+(defn make-application-must-resolve
+  []
+  (b/bids [{:wait-on #{:application-submitted}}
+           {:wait-on #{:account-opened :application-declined}
+            :hot true}]))
+
+(defn make-bthreads
+  []
+  {::account-opened-scenario (make-account-opened-scenario)
+   ::application-must-resolve (make-application-must-resolve)})
+```
+
+The scenario bthread gives us a concrete completion event that we can assert with `:possible`. The hot-state bthread says that once the application starts, we should not be able to deadlock, terminate, or loop forever before reaching either `:account-opened` or `:application-declined`.
+
 ### Model Checking
 
-We're going to wrap our bthreads into function calls to construct the domain, environment, and safety bthreads. Each namespace should define a `make-bthreads` function.
+We're going to wrap our bthreads into function calls to construct the domain, scenario, environment, and safety bthreads. Each namespace should define a `make-bthreads` function.
 
-Now, let's see what our model checker has to say. If it returns `nil`, then no violation was found.
+Now, let's see what our model checker has to say. If it returns `nil`, then no safety, reachability, deadlock, livelock, or hot-state liveness violation was found.
 
 ```clojure
 (defn run-model
   []
-  (-> {:bthreads (rules/make-bthreads) ;
-       :environment-bthreads (environment/make-bthreads)
-       :safety-bthreads (safety/make-bthreads)
-       :check-deadlock? false}
-     (check/check)))
+  (-> {:bthreads (merge (rules/make-bthreads)
+                        (scenarios/make-bthreads))
+        :environment-bthreads (environment/make-bthreads)
+        :safety-bthreads (safety/make-bthreads)
+        :possible #{:scenario/account-opened}
+        :check-deadlock? false}
+      (check/check)))
 ```
+
+In this setup:
+
+- `:possible #{:scenario/account-opened}` proves that at least one path reaches a successful account-opening outcome
+- `:hot true` on the progress bthread checks that an in-flight application cannot get stuck or spin forever without resolving
 
 On a failure, the model checker provides not only the path, but the state of the bthreads, which is very useful for debugging. (LLMs work great with this as well.)
 

--- a/modules/pavlov-skills/skills/pavlov-domain-modeling/references/bthread-templates.md
+++ b/modules/pavlov-skills/skills/pavlov-domain-modeling/references/bthread-templates.md
@@ -85,15 +85,10 @@
             [your.domain.environment :as environment]
             [your.domain.scenarios :as scenarios]))
 
-(defn make-liveness
+(defn make-possible
   []
-  {:red-foo-scenario-success
-   {:quantifier :existential
-    :eventually #{::scenarios/red-foo-scenario-success}}
-
-   :purple-foo-found-success
-   {:quantifier :existential
-    :eventually #{::scenarios/purple-foo-scenario-success}}})
+  #{::scenarios/red-foo-scenario-success
+    ::scenarios/purple-foo-scenario-success})
 
 (defn make-config [start-events]
   ;; Keep :bthreads as a map for equal-priority branching.
@@ -102,7 +97,7 @@
     {:bthreads bthreads
      :safety-bthreads (safety/make-bthreads)
      :environment-bthreads (environment/make-bthreads)
-     :liveness (make-liveness)}))
+     :possible (make-possible)}))
 
 (defn run-check [start-events]
   (check/check (make-config start-events)))

--- a/modules/pavlov-skills/skills/pavlov-domain-modeling/references/domain-session.md
+++ b/modules/pavlov-skills/skills/pavlov-domain-modeling/references/domain-session.md
@@ -42,12 +42,19 @@ These go in the `scenarios.clj` file
 
 These go in `rules.clj`.
 
-### Universal properties
+### Reachability goals
 
-- What must eventually happen on every path?
-- Are there terminal or resolution events required on all outcomes?
+- Which positive outcomes should be reachable on at least one path?
+- What completion events should be checked with `:possible`?
 
-These go in `rules.clj`
+These shape `scenarios.clj` and the `:possible` set in `check.clj`.
+
+### Progress obligations
+
+- Once the model enters an in-progress state, what must eventually be resolved?
+- Which bids should stay hot until some resolution happens?
+
+These go in `rules.clj`, typically by marking bids `:hot true`.
 
 ### Visualization goals
 

--- a/modules/pavlov-skills/skills/pavlov-model-checking/SKILL.md
+++ b/modules/pavlov-skills/skills/pavlov-model-checking/SKILL.md
@@ -36,7 +36,7 @@ A livelock means the model cycles forever without reaching a terminal event. Liv
 
 - Building or updating a model? See ./references/designing-models.md
 - Need API details or config options? Use docstrings.
-- Need concrete model-checking examples? Read the tests.
+- Need concrete model-checking examples? Start with the `tech.thomascothran.pavlov.model.check/check` docstring, then use the tests for edge cases.
 - Need help designing models and properties? Use the modeling reference.
 - Need to understand results? Use the interpretation reference.
 
@@ -47,6 +47,7 @@ A livelock means the model cycles forever without reaching a terminal event. Liv
    - safety bthreads that emit `:invariant-violated true`
    - hot-state obligations with `:hot true` on bids
    - reachability checks with `:possible`
+   - do not use legacy top-level `:liveness`; express progress with `:hot true`
 3. Run `tech.thomascothran.pavlov.model.check/check` with your config map.
 4. Interpret the result using `references/interpret-results.md` (resource `skills/pavlov-model-checking/references/interpret-results.md`).
 5. Iterate on model and properties before implementation details.
@@ -62,8 +63,9 @@ For the detailed workflow, read the Best practices section in the `tech.thomasco
 ## Where to look
 
 - Docstrings: `clojure.repl/doc` on `tech.thomascothran.pavlov.model.check/check`.
-- Tests (canonical examples): resource `tech/thomascothran/pavlov/model/check_test.clj`.
+- Tests (edge cases and regression coverage): resource `tech/thomascothran/pavlov/model/check_test.clj`.
 - Repo path: `modules/pavlov-devtools/test/tech/thomascothran/pavlov/model/check_test.clj`.
+- Direct hot-state liveness coverage: resource `tech/thomascothran/pavlov/model/check/liveness_test.clj`.
 - Modeling guidance: resource `skills/pavlov-model-checking/references/designing-models.md`.
 - Result interpretation: resource `skills/pavlov-model-checking/references/interpret-results.md`.
 - REPL setup: resource `skills/pavlov-model-checking/references/model-checker-repl.md`.

--- a/modules/pavlov-skills/skills/pavlov-model-checking/SKILL.md
+++ b/modules/pavlov-skills/skills/pavlov-model-checking/SKILL.md
@@ -5,7 +5,7 @@ description: Model checking for Pavlov behavioral programs. Use when testing Pav
 
 # Pavlov model checking
 
-Pavlov model checking explores all reachable event traces for a set of bthreads, reporting deadlocks, livelocks, safety violations, and liveness violations. It is designed for model-first development: specify the behavior and properties, run the checker, then iterate on implementation.
+Pavlov model checking explores all reachable event traces for a set of bthreads, reporting deadlocks, livelocks, safety violations, hot-state liveness violations, and impossible events. It is designed for model-first development: specify the behavior and properties, run the checker, then iterate on implementation.
 
 ## Terminology
 
@@ -13,12 +13,16 @@ Pavlov model checking explores all reachable event traces for a set of bthreads,
 
 Safety properties say "something bad never happens." In Pavlov, safety checks are defined as *safety bthreads* and passed under `:safety-bthreads`. They monitor the trace and emit an event with `:invariant-violated true` when the rule is broken.
 
-### Liveness properties
+### Hot-state liveness
 
-Liveness properties say "something good eventually happens." In Pavlov, liveness checks are expressed alongside the model (conceptually like bthreads that inspect traces) using the `:liveness` map passed to `check/check`.
+Hot-state liveness says that once the model enters certain states, progress is required. In Pavlov, liveness is expressed directly on bids with `:hot true`.
 
-- **Universal** (`:quantifier :universal`) means the event or predicate must hold on *every* path (aka the trace).
-- **Existential** (`:quantifier :existential`) means the event or predicate must hold on *at least one* path (aka the trace).
+- A hot-state violation happens when execution terminates while hot, deadlocks while hot, or can remain hot forever.
+- `check/check` reports at most one hot-state witness under `:liveness-violation`.
+
+### Possibility checks
+
+Use `:possible` when you want to prove that an event is reachable on at least one path.
 
 ### Deadlocks
 
@@ -41,7 +45,8 @@ A livelock means the model cycles forever without reaching a terminal event. Liv
 1. Define bthread factories that return fresh instances per run.
 2. Specify properties:
    - safety bthreads that emit `:invariant-violated true`
-   - liveness properties via the `:liveness` map
+   - hot-state obligations with `:hot true` on bids
+   - reachability checks with `:possible`
 3. Run `tech.thomascothran.pavlov.model.check/check` with your config map.
 4. Interpret the result using `references/interpret-results.md` (resource `skills/pavlov-model-checking/references/interpret-results.md`).
 5. Iterate on model and properties before implementation details.
@@ -50,7 +55,7 @@ A livelock means the model cycles forever without reaching a terminal event. Liv
 
 - Use a single `check/check` call per bthread group to cover all scenarios.
 - Create one initiating bthread whose first bid requests a *set* of starting events to form the top-level branch.
-- Model each positive scenario as its own bthread and assert its completion event with an existential liveness property.
+- Model each positive scenario as its own bthread and assert its completion event with `:possible`.
 
 For the detailed workflow, read the Best practices section in the `tech.thomascothran.pavlov.model.check` docstring.
 

--- a/modules/pavlov-skills/skills/pavlov-model-checking/references/designing-models.md
+++ b/modules/pavlov-skills/skills/pavlov-model-checking/references/designing-models.md
@@ -2,7 +2,7 @@
 
 This guide focuses on model-first development: define the behavior and properties in a small model, check it, then iterate on implementation.
 
-The model checker will take *all* the positive scenarios (what the application should do), *all* your safety and liveness properties, and examine all the execution paths to check the properties of your program.
+The model checker will take *all* the positive scenarios (what the application should do), *all* your safety and progress constraints, and examine all the execution paths to check the properties of your program.
 
 Generally, there should be one model for your entire feature.
 
@@ -12,12 +12,16 @@ Generally, there should be one model for your entire feature.
 
 Safety properties say "something bad never happens." In Pavlov, safety checks are defined as *safety bthreads* and passed under `:safety-bthreads`. They monitor the trace and emit an event with `:invariant-violated true` when the rule is broken.
 
-### Liveness properties
+### Hot-state liveness
 
-Liveness properties say "something good eventually happens." In Pavlov, liveness checks are expressed alongside the model (conceptually like bthreads that inspect traces) using the `:liveness` map passed to `check/check`.
+Hot-state liveness says that once the model reaches certain bids, progress is required. In Pavlov, express that directly on bids with `:hot true`.
 
-- **Universal** (`:quantifier :universal`) means the event or predicate must hold on *every* path.
-- **Existential** (`:quantifier :existential`) means the event or predicate must hold on *at least one* path.
+- A hot-state violation happens when execution terminates while hot, deadlocks while hot, or can remain hot forever.
+- `check/check` returns at most one hot-state witness under `:liveness-violation`.
+
+### Possibility checks
+
+Use `:possible` to assert that an event can occur on at least one reachable path.
 
 ### Deadlocks
 
@@ -69,27 +73,26 @@ Note that you normally will want a namespaced event that only exists in your tes
 
 The function approach lets you add a bit more logic. However, these should still be linear.
 
-### 2) Turn scenario completion into liveness goals
+### 2) Turn scenario completion into possibility checks
 
-For each scenario, use the final event name as an **existential** liveness property. This asserts the scenario is *possible at least once*.
-
-```clojure
-{:liveness
- {:order-completes
-  {:quantifier :existential
-   :eventually #{::order-done-scenario-complete}}}}
-```
-
-You can also add a **universal** liveness property to ensure every path eventually resolves to a done or cancelled order.
+For each scenario, use the final event name in `:possible`. This asserts the scenario is reachable on at least one path.
 
 ```clojure
-{:liveness
- {:order-always-resolves
-  {:quantifier :universal
-   :eventually #{:order/done :order/cancelled}}}}
+{:possible #{::order-done-scenario-complete}}
 ```
 
-Add all your liveness properties.
+Use hot-state liveness when some in-progress state must eventually be resolved on every path.
+
+```clojure
+{:bthreads
+ {:order (b/bids [{:request #{:order/placed}}])
+  :await-resolution
+  (b/bids [{:wait-on #{:order/placed}}
+           {:wait-on #{:order/done :order/cancelled}
+            :hot true}])}}
+```
+
+Add all your scenario completion events to `:possible`, and use `:hot true` where progress is required.
 
 ### 3) Add safety bthreads
 

--- a/modules/pavlov-skills/skills/pavlov-model-checking/references/interpret-results.md
+++ b/modules/pavlov-skills/skills/pavlov-model-checking/references/interpret-results.md
@@ -6,12 +6,14 @@
 
 - `:deadlocks` — vectors of `{:path [...] :state {...}}` when no events are possible.
 - `:livelocks` — vectors of `{:path [...] :cycle [...]}` for infinite cycles.
+- `:impossible` — a set of event types from your configured `:possible` check that never appear on any reachable edge.
 - `:safety-violations` — vectors of `{:event {...} :path [...] :state {...}}` when a safety bthread emits `:invariant-violated true`.
-- `:liveness-violation` — a single hot-state witness map like `{:node-id ... :path-edges [...] :state {...}}` when a hot-state liveness obligation is not met.
+- `:liveness-violation` — a single hot-state witness map like `{:node-id ... :path-edges [...] :state {...}}`, optionally with `:cycle-edges [...]`, when a hot-state liveness obligation is not met.
 - `:truncated` — `true` if exploration stopped due to `:max-nodes`.
 
 ## What to do next
 
 - Inspect the violating `:path`, `:cycle`, `:path-edges`, or `:cycle-edges` witness to see how the violation is reached.
+- If you get `:impossible`, compare that set with your configured `:possible` events to see which expected scenarios were never reached.
 - Compare with the definitions in `tech/thomascothran/pavlov/model/check_test.clj` for expected shapes.
 - Use `clojure.repl/doc` or `source` on `tech.thomascothran.pavlov.model.check/check` for authoritative details.

--- a/modules/pavlov-skills/skills/pavlov-model-checking/references/interpret-results.md
+++ b/modules/pavlov-skills/skills/pavlov-model-checking/references/interpret-results.md
@@ -7,11 +7,11 @@
 - `:deadlocks` — vectors of `{:path [...] :state {...}}` when no events are possible.
 - `:livelocks` — vectors of `{:path [...] :cycle [...]}` for infinite cycles.
 - `:safety-violations` — vectors of `{:event {...} :path [...] :state {...}}` when a safety bthread emits `:invariant-violated true`.
-- `:liveness-violations` — vectors of `{:property ... :quantifier ... :trace [...]}` when a liveness property fails.
+- `:liveness-violation` — a single hot-state witness map like `{:node-id ... :path-edges [...] :state {...}}` when a hot-state liveness obligation is not met.
 - `:truncated` — `true` if exploration stopped due to `:max-nodes`.
 
 ## What to do next
 
-- Inspect the violating `:path`/`:trace` to see the event sequence.
+- Inspect the violating `:path`, `:cycle`, `:path-edges`, or `:cycle-edges` witness to see how the violation is reached.
 - Compare with the definitions in `tech/thomascothran/pavlov/model/check_test.clj` for expected shapes.
 - Use `clojure.repl/doc` or `source` on `tech.thomascothran.pavlov.model.check/check` for authoritative details.

--- a/modules/pavlov-skills/skills/pavlov-model-checking/references/model-checker-repl.md
+++ b/modules/pavlov-skills/skills/pavlov-model-checking/references/model-checker-repl.md
@@ -11,8 +11,12 @@
 
 ## Pull examples from tests
 
-- The canonical examples live in `tech/thomascothran/pavlov/model/check_test.clj`.
-- Copy a `check/check` invocation from the tests into the REPL and iterate.
+- Start with `(clojure.repl/doc tech.thomascothran.pavlov.model.check/check)` for the current public API and example shapes.
+- For executable examples, prefer hot-state liveness and `:possible` cases from:
+  - `tech/thomascothran/pavlov/model/check_test.clj`
+  - `tech/thomascothran/pavlov/model/check/liveness_test.clj`
+- In the REPL, express universal progress with `:hot true` on bids and existential reachability with `:possible`.
+- Do not use legacy top-level `:liveness` forms when writing new checks.
 
 ```clojure
 (slurp (io/resource "tech/thomascothran/pavlov/model/check_test.clj"))

--- a/modules/pavlov-web/build.clj
+++ b/modules/pavlov-web/build.clj
@@ -5,7 +5,7 @@
 
 (def lib 'tech.thomascothran/pavlov-web)
 ; alternatively, use MAJOR.MINOR.COMMITS:
-(def version (format "3.0.%s" (b/git-count-revs nil)))
+(def version (format "4.0.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 
 (defn- pom-template [version]

--- a/modules/pavlov/build.clj
+++ b/modules/pavlov/build.clj
@@ -5,7 +5,7 @@
 
 (def lib 'tech.thomascothran/pavlov)
 ; alternatively, use MAJOR.MINOR.COMMITS:
-(def version (format "3.0.%s" (b/git-count-revs nil)))
+(def version (format "4.0.%s" (b/git-count-revs nil)))
 (def class-dir "target/classes")
 
 (defn- pom-template [version]

--- a/modules/pavlov/src/tech/thomascothran/pavlov/bid/defaults.cljc
+++ b/modules/pavlov/src/tech/thomascothran/pavlov/bid/defaults.cljc
@@ -8,7 +8,8 @@
           (wait-on [this] (-> (get this :wait-on #{})
                               (set/difference (get this :request #{}))))
           (block [this] (get this :block #{}))
-          (bthreads [this] (get this :bthreads)))
+          (bthreads [this] (get this :bthreads))
+          (hot [this] (get this :hot)))
 
    :squint (extend-protocol proto/Bid
              object
@@ -16,7 +17,8 @@
              (wait-on [this] (-> (get this :wait-on #{})
                                  (set/difference (get this :request #{}))))
              (block [this] (get this :block #{}))
-             (bthreads [this] (get this :bthreads)))
+             (bthreads [this] (get this :bthreads))
+             (hot [this] (get this :hot)))
 
    :cljs (extend-protocol proto/Bid
 
@@ -26,17 +28,20 @@
                                (set/difference (get this :request #{}))))
            (block [this] (get this :block #{}))
            (bthreads [this] (get this :bthreads))
+           (hot [this] (get this :hot))
 
            cljs.core.PersistentHashMap
            (request [this] (get this :request #{}))
            (wait-on [this] (-> (get this :wait-on #{})
                                (set/difference (get this :request #{}))))
            (block [this] (get this :block #{}))
-           (bthreads [this] (get this :bthreads))))
+           (bthreads [this] (get this :bthreads))
+           (hot [this] (get this :hot))))
 
 (extend-protocol proto/Bid
   nil
   (request [_])
   (wait-on [_])
   (block [_])
-  (bthreads [_]))
+  (bthreads [_])
+  (hot [_]))

--- a/modules/pavlov/src/tech/thomascothran/pavlov/bid/proto.cljc
+++ b/modules/pavlov/src/tech/thomascothran/pavlov/bid/proto.cljc
@@ -9,4 +9,5 @@
   (request [this])
   (wait-on [this])
   (block [this])
-  (bthreads [this]))
+  (bthreads [this])
+  (hot [this]))


### PR DESCRIPTION
## Conceptual shift

### Old approach
The older liveness story was centered around external liveness properties over traces.

In practice, that meant reasoning in terms like:
- “after this point, some event must eventually happen”
- “a path is bad if a declared liveness obligation is never satisfied”

This made liveness feel like a property layered on top of the model, rather than something expressed directly in the behavioral state of the bthreads.

It also pushed the implementation toward special-purpose path analysis:
- terminal reachability logic
- trapped/dead-end logic
- cycle search logic
- witness reconstruction from nodes back into event summaries

### New approach

The new implementation shifts to Harel-style hot states.

That means:
- a bid may declare :hot true
- an LTS node is hot if any active bid in that state is hot
- a run is bad if the system:
  1. terminates while hot
  2. deadlocks while hot
  3. can stay in hot states forever

This is a more BP-native formulation:
- liveness is expressed behaviorally
- obligations live in the modeled state itself
- the checker asks whether the system can get “stuck in hotness”

So the conceptual change is:
> from event-target eventuality checking over traces  
> to hot-state checking over the LTS

## Modeling change

### Old style
Mainly expressed liveness through top-level checking configuration and path properties.

### New style
You express liveness directly in bids:

```clojure
{:request #{:some-event}
 :hot true}
```

This means:
- entering that bid enters a hot region
- leaving it exits the hot region
- the checker must reject executions that never escape that hot region, or end there
This aligns with the classic behavioral-programming literature.

## Algorithmic shift

### Old algorithmic flavor
The older style required more indirect path reasoning:
- identify whether obligations were satisfied on traces
- reason about trapped nodes / terminal behavior
- reconstruct witnesses as event-type summaries
That style was more vulnerable to ambiguity in a merged graph.

### New algorithmic structure
The new checker is structurally simpler and more direct:
####  Compute hotness
For each node:
- node is hot if any active bid is hot

#### Finite hot violations
Detect:

1. hot terminal violation
   - a terminal edge whose target node is hot
2. hot deadlock violation
   - a reachable non-terminal leaf node that is hot

#### Infinite hot violations
Detect hot cycle violation as a reachable cycle consisting entirely of hot nodes

### Witness construction
Construct exact witnesses from the graph itself, using edges.

So the checker now works as:
- build the LTS
- identify hot nodes
- check hot terminal violations
- check hot deadlocks
- search for a hot-only cycle

That is much closer to standard hot-state model checking.

#### Witness/API shift

This is the most visible API change.
##### Old direct API
`tech.thomascothran.pavlov.model.check.liveness/liveness-violation` used to return event-type summaries like:

```clojure
{:node-id ...
 :path [...]
 :cycle [...]
 :state ...}
```

Problems with that:
- it was lossy
- in a merged graph, node identity is not enough to recover the exact witness
- terminal violations could report a path that reached the node but omitted the actual violating terminal edge
- 
##### New direct API
It now returns exact edge witnesses:

```clojure
{:node-id ...
 :path-edges [...]
 :cycle-edges [...]
 :state ...}
```

with:
- :path-edges = exact root-to-node edge witness
- :cycle-edges = exact cycle witness when the violation is cyclic
and the old keys are gone:
- no :path
- no :cycle
This is a real breaking change, but it is a much better fit for merged LTS semantics.

### Why this API change was needed
Because in a merged graph:
- a node tells you which state
- it does not tell you which incoming edge/path

That matters especially for:
- terminal violations, which are really edge-based
- cycle violations, which need an exact repeating witness
- deadlock witnesses, which must actually be reachable from the root

So the new API stops pretending that a compact event-type list is always enough.

Instead it returns the actual graph proof.

## Specific algorithm choices in the new implementation

The current implementation makes these concrete choices:

### Hot terminal detection
- scan edges in graph order
- find the first terminal edge whose target node is hot
- witness = rooted prefix to edge.from + the exact terminal edge

### Hot deadlock detection
- compute deadlock node ids from:
  - leaf nodes
  - excluding terminal targets
- choose the first hot reachable deadlock node in natural node order
- witness = exact rooted edge path to that node

### Hot cycle detection
- restrict search to hot nodes
- run DFS-style cycle detection over the hot subgraph
- use deterministic traversal order from the LTS edge order / natural node order
- witness =
  - :path-edges to the cycle entry
  - :cycle-edges for the loop itself

So the checker is now explicitly:
- hot-state based
- edge-witness based
- merged-graph aware

## What improved

### Better semantics
The checker now matches the hot-state model from Harel-style BP.

### Better modeling
Liveness can be expressed behaviorally with :hot true.

### Better witnesses
Returned witnesses now correspond to the actual violating execution.

### Better implementation fit
The algorithm now matches the domain more directly:
- finite hot failure
- infinite hot failure
instead of trying to infer everything from summarized traces.
